### PR TITLE
优化对象的重复实例化，并提升协程环境下的性能

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
 - 一键启动，安装后即可启动，同时支持配置复杂的功能。
 - 一个项目支持多个MCP服务器，并按服务器名称隔离配置。
 - 与Webman框架深度集成，HTTP支持路由模式和自定义进程模式。
-- 自动注册MCP服务到主流IDE（VSCode、Cursor、通义灵码等）
-- 支持 STDIO、Streamable HTTP 高性能传输
-- 内置MCP命令行开发工具
+- 自动注册MCP服务到主流IDE（VSCode、Cursor、通义灵码等）。
+- 支持 STDIO、Streamable HTTP 高性能传输。
+- 支持协程与非协程，从而提高了在sse场景下高性能传输。
+- 内置MCP命令行开发工具。
 
 ## 安装
 
@@ -31,7 +32,7 @@ composer require luoyue/webman-mcp
 - monolog/monolog（可选，用于记录服务器日志）
 - phpunit/phpunit（可选，用于无关传输的测试）
 
-### 启动方式
+## 启动方式
 
 ```shell
 # 启动 MCP STDIO 服务器, mcp为服务器名称，配置文件中定义

--- a/src/Server/StreamableHttpTransport.php
+++ b/src/Server/StreamableHttpTransport.php
@@ -2,15 +2,18 @@
 
 namespace Luoyue\WebmanMcp\Server;
 
+use Mcp\Schema\JsonRpc\Error;
+use Mcp\Server\Transport\CallbackStream;
 use \Mcp\Server\Transport\StreamableHttpTransport as BaseStreamableHttpTransport;
 use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use Symfony\Component\Uid\Uuid;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\ServerSentEvents;
+use Workerman\Timer;
 
 class StreamableHttpTransport extends BaseStreamableHttpTransport
 {
@@ -21,14 +24,81 @@ class StreamableHttpTransport extends BaseStreamableHttpTransport
      * @param array<string, string> $corsHeaders
      */
     public function __construct(
-        private readonly ServerRequestInterface $request,
-        ?ResponseFactoryInterface $responseFactory = null,
-        ?StreamFactoryInterface $streamFactory = null,
-        array $corsHeaders = [],
-        LoggerInterface $logger = new NullLogger(),
+        private readonly ServerRequestInterface    $request,
+        private readonly ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface                    $streamFactory = null,
+        array                                      $corsHeaders = [],
+        ?LoggerInterface                           $logger = null,
     ) {
         $this->connection = $request->getAttribute(TcpConnection::class);
         parent::__construct($request, $responseFactory, $streamFactory, $corsHeaders, $logger);
+    }
+
+    protected function createStreamedResponse(): ResponseInterface
+    {
+        $callback = function (): void {
+            try {
+                $this->logger->info('SSE: Starting request processing loop');
+
+                while ($this->sessionFiber->isSuspended()) {
+                    $this->flushOutgoingMessages($this->sessionId);
+
+                    $pendingRequests = $this->getPendingRequests($this->sessionId);
+
+                    if (empty($pendingRequests)) {
+                        $yielded = $this->sessionFiber->resume();
+                        $this->handleFiberYield($yielded, $this->sessionId);
+                        continue;
+                    }
+
+                    $resumed = false;
+                    foreach ($pendingRequests as $pending) {
+                        $requestId = $pending['request_id'];
+                        $timestamp = $pending['timestamp'];
+                        $timeout = $pending['timeout'] ?? 120;
+
+                        $response = $this->checkForResponse($requestId, $this->sessionId);
+
+                        if (null !== $response) {
+                            $yielded = $this->sessionFiber->resume($response);
+                            $this->handleFiberYield($yielded, $this->sessionId);
+                            $resumed = true;
+                            break;
+                        }
+
+                        if (time() - $timestamp >= $timeout) {
+                            $error = Error::forInternalError('Request timed out', $requestId);
+                            $yielded = $this->sessionFiber->resume($error);
+                            $this->handleFiberYield($yielded, $this->sessionId);
+                            $resumed = true;
+                            break;
+                        }
+                    }
+
+                    if (!$resumed) {
+                        Timer::sleep(0.1);
+                    } // Prevent tight loop
+                }
+
+                $this->handleFiberTermination();
+            } finally {
+                $this->sessionFiber = null;
+            }
+        };
+
+        $stream = new CallbackStream($callback, $this->logger);
+        $response = $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/event-stream')
+            ->withHeader('Cache-Control', 'no-cache')
+            ->withHeader('Connection', 'keep-alive')
+            ->withHeader('X-Accel-Buffering', 'no')
+            ->withBody($stream);
+
+        if ($this->sessionId) {
+            $response = $response->withHeader('Mcp-Session-Id', $this->sessionId->toRfc4122());
+        }
+
+        return $this->withCorsHeaders($response);
     }
 
     protected function handleFiberTermination(): void


### PR DESCRIPTION
- 取消重复实例化Server，并增加对transport的管理
- 将sleep替换为协程方法
等待https://github.com/modelcontextprotocol/php-sdk/pull/160 合并