### PR TITLE
优化DevMcp工具注解与默认配置，同步更新文档

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/deepseek-v4-flash-free

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## 这是什么
+
+`webman-mcp` 是一个 Composer **库 / webman 插件**（`luoyue/webman-mcp`），封装官方 MCP PHP SDK（`mcp/sdk ^0.6`）。它**不是独立应用**：`src/` 中的代码只在 webman 应用内运行，依赖 webman 全局函数/类（`config()`、`base_path()`、`runtime_path()`、`request()`、`response()`、`support\Container`、`support\Context`）。PHP >= 8.1。
+
+## 目录结构
+
+- `src/` — 插件源码，PSR-4 `Luoyue\WebmanMcp\`
+- `src/config/plugin/luoyue/webman-mcp/` — 默认配置，由 `src/Install.php` 复制到应用目录 `config/plugin/luoyue/webman-mcp/`
+- `src/Runner/` — 接线层：`McpRouterRunner`（路由）、`McpProcessRunner`（workerman 进程）、`McpAutoLoadRunner`（bootstrap，仅 Windows）、`McpCommandRunner`（控制台命令）
+- `src/Command/` — 控制台命令：mcp:server / mcp:list / mcp:make / mcp:inspector
+- `src/DevMcp/` — 内置开发工具（System/Redis/Database）；**PHPStan 排除**
+- `tests/` — PSR-4 `Luoyue\WebmanMcp\Tests\`；`tests/Bootstrap.php` 从 `tests/config/` 加载 webman `Config`（配置前缀 `plugin.luoyue.webman-mcp`）
+- `tests/phpunit/` — 单元测试套件 `unit`；`tests/Conformance/` — conformance 服务器与预期失败基线
+
+## 命令
+
+- 单元测试：`vendor/bin/phpunit --testsuite=unit`（没有 `composer test` 脚本）
+- 风格：`composer cs:check` / `composer cs:fix` — fixer 只扫描 `./src`，**不扫描 tests**
+- 静态分析：`composer phpstan`（level 6；扫描 `src/` 和 `tests/`，排除 `src/DevMcp/`；少量 ignoreErrors 固定在 `phpstan.dist.neon`）
+- CI（`.github/workflows/pipeline.yml`，触发：pull_request）的 qa job 顺序：`composer validate --strict` → `vendor/bin/php-cs-fixer fix --dry-run` → `vendor/bin/phpstan analyse`
+- CI 另有 unit job：PHP 8.1–8.5 × lowest/highest 依赖矩阵；conformance job：PHP 8.1 × 扩展 pcntl/event/ev/swoole/swow/fiber 矩阵（扩展矩阵仅 conformance job，非 unit job）
+
+## 架构 / 入口
+
+- `McpServerManager::start($name)` 是唯一分发点（src/McpServerManager.php:105），依据 `$_ENV['MCP_STDIO']` 分支 STDIO 与 HTTP 传输。
+- STDIO 模式：`php webman mcp:server <service>` → `McpStdioCommand` 设置 `$_ENV['MCP_STDIO']=true`（src/Command/McpStdioCommand.php:24）。
+- HTTP 路由模式：`McpRouterRunner` 对 `transport.streamable_http.router.enable=true` 的服务注册 `Route::any($endpoint, ...)`。
+- HTTP 进程模式：`McpProcessRunner::create()` 从 `transport.streamable_http.process` 构建 workerman 进程配置（由插件 `process.php` 返回）；每个端口的端点必须唯一。
+- 配置从 `config('plugin.luoyue.webman-mcp.mcp')` 读取，由 `McpServerManager::loadConfig()` 每进程缓存一次（static `$isInit` 标志）。
+- 常量 `McpServerManager::PLUGIN_REWFIX` 故意拼错（"REWFIX"）；用它而不要用字面量。
+- 工具/提示/资源注解通过 `DiscoveryLoader` + `WebmanDiscoverer` 扫描 `app/mcp` 发现。
+
+## 注意事项
+
+- **不要**加 `declare(strict_types=1)` — cs-fixer 配置强制 `declare_strict_types => false`。
+- `transport.streamable_http.middleware` 接受 PSR-15 中间件对象或类名字符串（类字符串通过 `Container` 解析）。
+- Windows 上 STDIO 传输无法非阻塞，因此 `mcp:server` 模式下定时器/协程/http-client 不可用（README 有说明）。
+- Conformance：CI 先 `php tests/Conformance/server.php start -d`（服务 `conformance` 来自 `tests/config/mcp.php`，端口 8000，端点 `/mcp`），再运行 `modelcontextprotocol/conformance`，预期失败固定在 `tests/Conformance/conformance-baseline.yml`。
+- README、提交信息、配置注释均为中文。

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - 自动注册MCP服务到主流IDE（VSCode、Cursor、通义灵码等）。
 - 支持 STDIO、Streamable HTTP 高性能传输。
 - 支持协程与非协程，从而提高了在sse场景下高性能传输。
-- 内置常用20+个MCP开发工具，提升开发效率。
+- 内置18个MCP开发工具，提升开发效率。
 
 ## 安装
 
@@ -25,17 +25,15 @@ composer require luoyue/webman-mcp
 ### 环境要求
 
 - PHP >= 8.1
-- webman^2.1
-- webman/cache^2.1
+- webman ^2.1
 
 ### 可选依赖
 
 - webman/cache（session持久化存储）
-- webman/redis（session存储到redis）
-- webman/event（用于MCP生命周期钩子）
-- Swoole/Swow/Fiber协程（提升SSE性能）
-- monolog/monolog（用于记录服务器日志）
-- guzzlehttp/guzzle（用于MCP客户端HTTP请求）
+- webman/redis（Redis开发工具）
+- webman/event（MCP生命周期钩子与列表变更通知）
+- Swoole/Swow/Fiber协程（提升SSE传输性能）
+- monolog/monolog（记录服务器日志）
 
 ## 注解
 
@@ -82,6 +80,8 @@ return [
     'enable' => true,
     // 自动注册MCP服务到ide中
     'auto_register_client' => McpClientRegisterEnum::CURSOR_IDE,
+    // 事件分发模式: dispatch或emit
+    'event_mode' => 'dispatch',
 ];
 ```
 
@@ -90,7 +90,7 @@ return [
 ### 3. 测试您的服务器
 
 ```bash
-# 使用 MCP Inspector 测试（需要node与npx）
+# 使用 MCP Inspector 测试（需要Node.js，使用npx或bunx）
 php webman mcp:inspector mcp
 ```
 
@@ -114,30 +114,32 @@ php webman mcp:list
 
 ### MCP开发工具
 
-|  类别  |          名称           | 描述                                     |
-|:----:|:---------------------:|:---------------------------------------:|
-| tool |      system_info      | 获取系统环境信息                              |
-| tool |     system_config     | 获取应用配置值                                |
-| tool |      system_env       | 获取环境变量                                 |
-| tool |    system_php_ini     | 获取PHP配置信息                              |
-| tool |  system_dependencies  | 获取项目Composer依赖列表                       |
-| tool |   system_extensions   | 获取已加载的PHP扩展及函数                        |
-| tool |     system_routes     | 获取路由列表                                 |
-| tool |  system_match_routes  | 匹配URL对应的路由                             |
-| tool |     system_events     | 获取事件列表                                 |
-| tool |   system_eval_code    | 执行PHP代码（有安全风险，请谨慎使用）                   |
-| tool |   system_build_phar   | 将项目打包为PHAR文件                           |
-| tool |   system_build_bin    | 将项目打包为Linux二进制文件                       |
-| tool | database_connections  | 获取数据库连接配置                              |
-| tool | database_execute_sql  | 执行原始SQL语句（支持参数绑定）                      |
-| tool |   redis_connections   | 获取Redis连接配置                            |
-| tool |   redis_execute_raw   | 执行原始Redis命令                            |
-| tool |   redis_execute_lua   | 执行Redis Lua脚本                          |
-| tool | redis_execute_lua_sha | 通过SHA1执行Redis Lua脚本                    |
+|  类别  |          名称           |          描述          |
+|:----:|:---------------------:|:--------------------:|
+| tool |      system_info      |       获取系统环境信息       |
+| tool |     system_config     |       获取应用配置值        |
+| tool |      system_env       |        获取环境变量        |
+| tool |    system_php_ini     |      获取PHP配置信息       |
+| tool |  system_dependencies  |   获取项目Composer依赖列表   |
+| tool |   system_extensions   |    获取已加载的PHP扩展及函数    |
+| tool |     system_routes     |        获取路由列表        |
+| tool |  system_match_routes  |      匹配URL对应的路由      |
+| tool |     system_events     |        获取事件列表        |
+| tool |   system_eval_code    | 执行PHP代码（有安全风险，请谨慎使用） |
+| tool |   system_build_phar   |     将项目打包为PHAR文件     |
+| tool |   system_build_bin    |   将项目打包为Linux二进制文件   |
+| tool | database_connections  |      获取数据库连接配置       |
+| tool | database_execute_sql  |  执行原始SQL语句（支持参数绑定）   |
+| tool |   redis_connections   |     获取Redis连接配置      |
+| tool |   redis_execute_raw   |     执行原始Redis命令      |
+| tool |   redis_execute_lua   |    执行Redis Lua脚本     |
+| tool | redis_execute_lua_sha | 通过SHA1执行Redis Lua脚本  |
 
 ## 日志记录
 
 ### 发送客户端日志
+
+> 注意：`2026-07-28`规范已废弃客户端日志（client logging），但1年内依然可用。
 
 请参考[官方文档](https://github.com/modelcontextprotocol/php-sdk/blob/main/docs/client-communication.md)
 
@@ -153,10 +155,10 @@ php webman mcp:list
 
 从以上表格中看出：
 
-- 在开发环境中使用stderr很方便的将日在控制台中且不影响运行。
+- 在开发环境中使用stderr很方便的将日志输出到控制台中且不影响运行。
 - 在生产环境中使用file记录日志可以将日志保存在磁盘中，方便后续维护。
 
-配置monolog（必须是插件目录下的log.php）：
+配置monolog日志通道（插件配置目录 `config/plugin/luoyue/webman-mcp/log.php`）：
 
 ```php
 <?php
@@ -198,14 +200,26 @@ return [
 ];
 ```
 
-然后我们可以在`mcp.php`中配置以下逻辑：
+然后在`mcp.php`的`configure`闭包中为服务器设置日志通道。`setLogger`支持任意monolog channel：
 
 ```php
-return [
-    'mcp' => [
-        'logger' => config('app.debug', true) ? 'mcp_error_stderr' : 'mcp_file_log'
-  ]
-]
+'configure' => function (\Mcp\Server\Builder $server) {
+    // ...
+    // 直接使用应用任意已配置的channel
+    $server->setLogger(\support\Log::channel('default'));
+}
+```
+
+如果使用插件自带的channel，通道名需要加上`plugin.luoyue.webman-mcp.`前缀，例如根据debug模式在stderr与文件日志之间切换：
+
+```php
+'configure' => function (\Mcp\Server\Builder $server) {
+    // ...
+    $server->setLogger(\support\Log::channel(
+        \Luoyue\WebmanMcp\McpServerManager::PLUGIN_REWFIX .
+        (config('app.debug', true) ? 'mcp_error_stderr' : 'mcp_file_log')
+    ));
+}
 ```
 
 ## 与webman的兼容问题

--- a/README.md
+++ b/README.md
@@ -114,27 +114,26 @@ php webman mcp:list
 
 ### MCP开发工具
 
-|  类别  |          名称           | 描述                               |
-|:----:|:---------------------:|:---------------------------------|
-| tool |      system_info      | 获取webman框架信息，php版本信息，系统信息，是否使用协程 |
-| tool |      get_config       | 获取config配置信息                     |
-| tool |        get_env        | 获取env环境变量信息                      |
-| tool |     list_process      | 获取进程列表                           |
-| tool |      list_routes      | 获取路由列表                           |
-| tool |     match_routes      | 匹配url对应的路由信息                     |
-| tool |    list_dependence    | 获取项目依赖列表                         |
-| tool |    list_extensions    | 获取当前环境已加载的php扩展                  |
-| tool |  get_extension_funcs  | 获取扩展已加载的函数                       |
-| tool |      list_events      | 获取事件列表                           |
-| tool |       eval_code       | 执行php代码                          |
-| tool |      build_phar       | 将项目代码打包为phar文件                   |
-| tool |       build_bin       | 将项目代码打包为linux二进制可执行文件            |
-| tool | database_connections  | 获取数据库连接配置信息列表                    |
-| tool | database_execute_sql  | 执行原始sql脚本                        |
-| tool |   redis_connections   | 获取数据库redis配置信息列表                 |
-| tool |   redis_execute_raw   | 执行原始Redis命令                      |
-| tool |   redis_execute_lua   | 执行Redis Lua脚本                    |
-| tool | redis_execute_lua_sha | 使用sha1执行Redis Lua脚本              |
+|  类别  |          名称           | 描述                                     |
+|:----:|:---------------------:|:---------------------------------------:|
+| tool |      system_info      | 获取系统环境信息                              |
+| tool |     system_config     | 获取应用配置值                                |
+| tool |      system_env       | 获取环境变量                                 |
+| tool |    system_php_ini     | 获取PHP配置信息                              |
+| tool |  system_dependencies  | 获取项目Composer依赖列表                       |
+| tool |   system_extensions   | 获取已加载的PHP扩展及函数                        |
+| tool |     system_routes     | 获取路由列表                                 |
+| tool |  system_match_routes  | 匹配URL对应的路由                             |
+| tool |     system_events     | 获取事件列表                                 |
+| tool |   system_eval_code    | 执行PHP代码（有安全风险，请谨慎使用）                   |
+| tool |   system_build_phar   | 将项目打包为PHAR文件                           |
+| tool |   system_build_bin    | 将项目打包为Linux二进制文件                       |
+| tool | database_connections  | 获取数据库连接配置                              |
+| tool | database_execute_sql  | 执行原始SQL语句（支持参数绑定）                      |
+| tool |   redis_connections   | 获取Redis连接配置                            |
+| tool |   redis_execute_raw   | 执行原始Redis命令                            |
+| tool |   redis_execute_lua   | 执行Redis Lua脚本                          |
+| tool | redis_execute_lua_sha | 通过SHA1执行Redis Lua脚本                    |
 
 ## 日志记录
 

--- a/src/DevMcp/Database.php
+++ b/src/DevMcp/Database.php
@@ -13,8 +13,8 @@ class Database
 {
     #[McpTool(
         name: 'database_connections',
-        title: '获取数据库连接配置信息',
-        description: '获取所有数据库连接的配置信息，包括驱动、数据库名、表前缀、连接池等',
+        title: '获取数据库连接配置',
+        description: '获取所有数据库连接的配置信息，包括驱动、数据库名、表前缀及连接池等',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -69,7 +69,7 @@ class Database
     #[McpTool(
         name: 'database_execute_sql',
         title: '执行原始SQL语句',
-        description: '在指定数据库连接上执行原始SQL语句，支持参数绑定防止SQL注入',
+        description: '在指定数据库连接上执行原始SQL语句，支持参数绑定以防止SQL注入',
         outputSchema: [
             'type' => 'object',
             'properties' => [

--- a/src/DevMcp/Database.php
+++ b/src/DevMcp/Database.php
@@ -13,7 +13,8 @@ class Database
 {
     #[McpTool(
         name: 'database_connections',
-        description: '获取数据库redis配置信息列表',
+        title: '获取数据库连接配置信息',
+        description: '获取所有数据库连接的配置信息，包括驱动、数据库名、表前缀、连接池等',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -67,7 +68,8 @@ class Database
 
     #[McpTool(
         name: 'database_execute_sql',
-        description: '执行原始sql脚本',
+        title: '执行原始SQL语句',
+        description: '在指定数据库连接上执行原始SQL语句，支持参数绑定防止SQL注入',
         outputSchema: [
             'type' => 'object',
             'properties' => [

--- a/src/DevMcp/Redis.php
+++ b/src/DevMcp/Redis.php
@@ -13,8 +13,8 @@ class Redis
 {
     #[McpTool(
         name: 'redis_connections',
-        title: '获取Redis连接配置信息',
-        description: '获取所有Redis连接的配置信息，包括数据库编号、连接池等',
+        title: '获取Redis连接配置',
+        description: '获取所有Redis连接的配置信息，包括数据库编号、前缀及连接池等',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -65,7 +65,7 @@ class Redis
     #[McpTool(
         name: 'redis_execute_raw',
         title: '执行原始Redis命令',
-        description: '在指定Redis连接上执行原始命令，支持切换数据库编号',
+        description: '在指定Redis连接上执行原始Redis命令，支持切换数据库编号，参数以数组形式传入',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -99,7 +99,7 @@ class Redis
     #[McpTool(
         name: 'redis_execute_lua',
         title: '执行Redis Lua脚本',
-        description: '在指定Redis连接上执行Lua脚本，支持键数量声明和参数传递',
+        description: '在指定Redis连接上执行Lua脚本，支持声明键数量并传递参数',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -134,7 +134,7 @@ class Redis
 
     #[McpTool(
         name: 'redis_execute_lua_sha',
-        title: '使用SHA1执行Redis Lua脚本',
+        title: '通过SHA1执行Redis Lua脚本',
         description: '使用SHA1摘要执行已缓存的Redis Lua脚本，避免重复传输脚本内容',
         outputSchema: [
             'type' => 'object',

--- a/src/DevMcp/Redis.php
+++ b/src/DevMcp/Redis.php
@@ -13,7 +13,8 @@ class Redis
 {
     #[McpTool(
         name: 'redis_connections',
-        description: '获取数据库连接配置信息',
+        title: '获取Redis连接配置信息',
+        description: '获取所有Redis连接的配置信息，包括数据库编号、连接池等',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -63,7 +64,8 @@ class Redis
 
     #[McpTool(
         name: 'redis_execute_raw',
-        description: '执行原始Redis命令',
+        title: '执行原始Redis命令',
+        description: '在指定Redis连接上执行原始命令，支持切换数据库编号',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -96,7 +98,8 @@ class Redis
 
     #[McpTool(
         name: 'redis_execute_lua',
-        description: '执行Redis Lua脚本',
+        title: '执行Redis Lua脚本',
+        description: '在指定Redis连接上执行Lua脚本，支持键数量声明和参数传递',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -131,7 +134,8 @@ class Redis
 
     #[McpTool(
         name: 'redis_execute_lua_sha',
-        description: '使用sha1执行Redis Lua脚本',
+        title: '使用SHA1执行Redis Lua脚本',
+        description: '使用SHA1摘要执行已缓存的Redis Lua脚本，避免重复传输脚本内容',
         outputSchema: [
             'type' => 'object',
             'properties' => [

--- a/src/DevMcp/System.php
+++ b/src/DevMcp/System.php
@@ -24,8 +24,8 @@ class System
 {
     #[McpTool(
         name: 'system_info',
-        title: '获取webman框架信息，php版本信息，系统信息，是否使用协程等',
-        description: '获取服务器操作系统、PHP版本、PHP二进制路径、Workerman/webman版本、事件循环驱动及协程状态等系统环境信息',
+        title: '获取系统环境信息',
+        description: '获取服务器操作系统、PHP版本与二进制路径、Workerman/webman版本、事件循环驱动及协程状态等系统环境信息',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -61,9 +61,9 @@ class System
     }
 
     #[McpTool(
-        name: 'list_dependence',
-        title: '获取当前项目已安装依赖列表',
-        description: '获取当前项目所有已安装的Composer依赖包信息，包括版本号、类型、安装路径、源码引用等',
+        name: 'system_dependencies',
+        title: '获取项目依赖列表',
+        description: '获取当前项目所有已安装的Composer依赖包信息，包括包名、版本、类型、安装路径及源码引用等',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -112,8 +112,8 @@ class System
      * @return string[]
      */
     #[McpTool(
-        name: 'list_extensions',
-        title: '获取当前环境已加载的PHP扩展及扩展函数列表',
+        name: 'system_extensions',
+        title: '获取已加载的PHP扩展',
         description: '获取当前PHP环境已加载的所有扩展及其提供的函数列表，以扩展名为键、函数数组为值',
         outputSchema: [
             'type' => 'object',
@@ -127,9 +127,9 @@ class System
     }
 
     #[McpTool(
-        name: 'get_php_ini',
+        name: 'system_php_ini',
         title: '获取PHP配置信息',
-        description: '获取PHP配置文件(php.ini)中的所有配置项及其当前值，可按扩展名筛选',
+        description: '获取PHP配置文件(php.ini)中的所有配置项及其当前值，可按扩展名筛选，便于排查PHP运行环境',
         outputSchema: [
             'type' => 'object',
         ]
@@ -143,9 +143,9 @@ class System
     }
 
     #[McpTool(
-        name: 'get_config',
-        title: '获取应用程序配置',
-        description: '通过配置路径获取应用程序的配置值，支持点号分隔的层级访问（如 "database.default"）',
+        name: 'system_config',
+        title: '获取应用配置',
+        description: '通过点号分隔的配置路径（如 "database.default"）获取应用程序的配置值',
         outputSchema: [
             'type' => 'object',
         ]
@@ -159,9 +159,9 @@ class System
     }
 
     #[McpTool(
-        name: 'list_routes',
+        name: 'system_routes',
         title: '获取路由列表',
-        description: '获取应用程序中所有已注册的路由及其请求方法、URI、回调处理器、中间件等信息',
+        description: '获取应用中所有已注册的路由，包括请求方法、URI、回调处理器、中间件及路由参数等信息',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -202,9 +202,9 @@ class System
     }
 
     #[McpTool(
-        name: 'match_routes',
-        title: '匹配URL对应的路由信息',
-        description: '根据URL路径和请求方法匹配对应的路由，返回匹配到的控制器、插件、动作及路由参数',
+        name: 'system_match_routes',
+        title: '匹配URL对应的路由',
+        description: '根据URL路径与请求方法匹配路由，返回控制器、插件、动作及路由参数，便于排查请求分发',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -282,9 +282,9 @@ class System
     }
 
     #[McpTool(
-        name: 'list_events',
+        name: 'system_events',
         title: '获取事件列表',
-        description: '获取所有已注册的webman事件及对应的回调函数列表',
+        description: '获取所有已注册的webman事件及其回调函数列表（依赖webman/event组件）',
         outputSchema: [
             'type' => 'object',
             'items' => [
@@ -318,9 +318,9 @@ class System
     }
 
     #[McpTool(
-        name: 'get_env',
-        title: '获取应用程序环境变量',
-        description: '获取应用程序的环境变量值，可按名称获取单个变量，不传参则获取全部环境变量',
+        name: 'system_env',
+        title: '获取环境变量',
+        description: '获取应用环境变量，可按名称获取单个变量，不传参则返回全部环境变量',
         outputSchema: [
             'type' => 'object',
             'anyOf' => [
@@ -339,8 +339,8 @@ class System
     }
 
     #[McpTool(
-        name: 'eval_code',
-        title: '在当前进程中执行PHP代码',
+        name: 'system_eval_code',
+        title: '执行PHP代码',
         description: '在当前服务进程中动态执行PHP代码并返回输出结果。注意：declare语句会被自动移除，class需用条件判断包裹。此操作有安全风险，请谨慎使用',
         outputSchema: [
             'type' => 'object',
@@ -370,8 +370,8 @@ class System
     }
 
     #[McpTool(
-        name: 'build_phar',
-        title: '将项目代码打包为PHAR文件',
+        name: 'system_build_phar',
+        title: '打包项目为PHAR文件',
         description: '将整个项目代码打包为PHAR归档文件，便于分发和部署',
         outputSchema: [
             'type' => 'object',
@@ -392,8 +392,8 @@ class System
     }
 
     #[McpTool(
-        name: 'build_bin',
-        title: '将项目代码打包为Linux二进制可执行文件',
+        name: 'system_build_bin',
+        title: '打包项目为Linux二进制文件',
         description: '将整个项目代码打包为Linux单文件二进制可执行程序，无需PHP环境即可独立运行',
         outputSchema: [
             'type' => 'object',

--- a/src/DevMcp/System.php
+++ b/src/DevMcp/System.php
@@ -24,7 +24,8 @@ class System
 {
     #[McpTool(
         name: 'system_info',
-        description: '获取webman框架信息，php版本信息，系统信息，是否使用协程等',
+        title: '获取webman框架信息，php版本信息，系统信息，是否使用协程等',
+        description: '获取服务器操作系统、PHP版本、PHP二进制路径、Workerman/webman版本、事件循环驱动及协程状态等系统环境信息',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -61,7 +62,8 @@ class System
 
     #[McpTool(
         name: 'list_dependence',
-        description: '获取当前项目已安装依赖列表',
+        title: '获取当前项目已安装依赖列表',
+        description: '获取当前项目所有已安装的Composer依赖包信息，包括版本号、类型、安装路径、源码引用等',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -111,7 +113,8 @@ class System
      */
     #[McpTool(
         name: 'list_extensions',
-        description: '获取当前环境已加载的php扩展以及扩展函数列表',
+        title: '获取当前环境已加载的PHP扩展及扩展函数列表',
+        description: '获取当前PHP环境已加载的所有扩展及其提供的函数列表，以扩展名为键、函数数组为值',
         outputSchema: [
             'type' => 'object',
         ]
@@ -125,7 +128,8 @@ class System
 
     #[McpTool(
         name: 'get_php_ini',
-        description: '获取php配置信息',
+        title: '获取PHP配置信息',
+        description: '获取PHP配置文件(php.ini)中的所有配置项及其当前值，可按扩展名筛选',
         outputSchema: [
             'type' => 'object',
         ]
@@ -140,7 +144,8 @@ class System
 
     #[McpTool(
         name: 'get_config',
-        description: '获取应用程序配置',
+        title: '获取应用程序配置',
+        description: '通过配置路径获取应用程序的配置值，支持点号分隔的层级访问（如 "database.default"）',
         outputSchema: [
             'type' => 'object',
         ]
@@ -155,7 +160,8 @@ class System
 
     #[McpTool(
         name: 'list_routes',
-        description: '获取路由列表',
+        title: '获取路由列表',
+        description: '获取应用程序中所有已注册的路由及其请求方法、URI、回调处理器、中间件等信息',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -197,7 +203,8 @@ class System
 
     #[McpTool(
         name: 'match_routes',
-        description: '匹配url对应的路由信息',
+        title: '匹配URL对应的路由信息',
+        description: '根据URL路径和请求方法匹配对应的路由，返回匹配到的控制器、插件、动作及路由参数',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -276,7 +283,8 @@ class System
 
     #[McpTool(
         name: 'list_events',
-        description: '获取事件列表',
+        title: '获取事件列表',
+        description: '获取所有已注册的webman事件及对应的回调函数列表',
         outputSchema: [
             'type' => 'object',
             'items' => [
@@ -311,7 +319,8 @@ class System
 
     #[McpTool(
         name: 'get_env',
-        description: '获取应用程序环境变量',
+        title: '获取应用程序环境变量',
+        description: '获取应用程序的环境变量值，可按名称获取单个变量，不传参则获取全部环境变量',
         outputSchema: [
             'type' => 'object',
             'anyOf' => [
@@ -331,7 +340,8 @@ class System
 
     #[McpTool(
         name: 'eval_code',
-        description: '在当前进程中执行php代码',
+        title: '在当前进程中执行PHP代码',
+        description: '在当前服务进程中动态执行PHP代码并返回输出结果。注意：declare语句会被自动移除，class需用条件判断包裹。此操作有安全风险，请谨慎使用',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -361,7 +371,8 @@ class System
 
     #[McpTool(
         name: 'build_phar',
-        description: '将项目代码打包为phar文件',
+        title: '将项目代码打包为PHAR文件',
+        description: '将整个项目代码打包为PHAR归档文件，便于分发和部署',
         outputSchema: [
             'type' => 'object',
             'properties' => [
@@ -382,7 +393,8 @@ class System
 
     #[McpTool(
         name: 'build_bin',
-        description: '将项目代码打包为linux二进制可执行文件',
+        title: '将项目代码打包为Linux二进制可执行文件',
+        description: '将整个项目代码打包为Linux单文件二进制可执行程序，无需PHP环境即可独立运行',
         outputSchema: [
             'type' => 'object',
             'properties' => [

--- a/src/config/plugin/luoyue/webman-mcp/mcp.php
+++ b/src/config/plugin/luoyue/webman-mcp/mcp.php
@@ -20,9 +20,9 @@ return [
         'configure' => function (Builder $server) {
             // 设置服务信息
             $server->setServerInfo(
-                name: 'MCP Server',
-                version: '0.0.1',
-                description: 'MCP Server',
+                name: 'Webman MCP 开发服务器',
+                version: '1.0.0',
+                description: '基于 webman 框架的 MCP 服务器，内置系统信息、数据库、Redis 等开发辅助工具',
                 icons: [
                     new Icon(
                         src: 'https://manual.workerman.net/favicon.ico',


### PR DESCRIPTION
## 变更内容

对 `src/DevMcp/` 下的内置开发工具注解进行整体优化，并同步更新默认配置与文档。

### DevMcp 工具注解优化（System / Redis / Database）

- **工具名称统一前缀**：System 下工具统一为 `system_` 前缀，与 `redis_`、`database_` 保持一致，便于 AI 识别工具领域。
  - `list_dependence` → `system_dependencies`（同时修正拼写）
  - `get_config` → `system_config`、`get_env` → `system_env`、`get_php_ini` → `system_php_ini`
  - `list_routes` → `system_routes`、`match_routes` → `system_match_routes`
  - `list_extensions` → `system_extensions`、`list_events` → `system_events`
  - `eval_code` → `system_eval_code`、`build_phar` → `system_build_phar`、`build_bin` → `system_build_bin`
- **title 精简**：去除冗余表述，改为简短动词短语（如「获取系统环境信息」「执行PHP代码」）。
- **description 补充**：完善工具用途、参数行为与依赖说明（如 `system_events` 注明依赖 webman/event），帮助 AI 更准确选择工具。

### 默认配置

- `mcp.php` 中 `setServerInfo` 的 name/description 修改为 Webman 开发服务器说明，关联内置 DevMcp 工具。

### 文档

- `README.md` 内置工具表同步为新名称与描述，移除代码中不存在的 `list_process`、`get_extension_funcs`，补入遗漏的 `system_php_ini`。
- 更新环境要求与可选依赖（工具数量 18、webman/redis 用途、移除未使用的 guzzle 等）。
- 修正日志配置示例为实际机制（`configure` 闭包中 `setLogger`，支持任意 channel，插件 channel 需 `plugin.luoyue.webman-mcp.` 前缀），并说明客户端日志已在 `2026-07-28` 规范废弃但 1 年内仍兼容。

> 注：本 PR 代码由 AI 辅助编写，请 Review 确认。