### PR TITLE
新增 mcp:tools 命令：列出服务工具/资源/提示及 Schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 composer.lock
 .php-cs-fixer.cache
 .phpunit.result.cache
+**.log

--- a/README.md
+++ b/README.md
@@ -105,12 +105,20 @@ php webman mcp:inspector mcp
 | mcp:make      |  type   |    生成MCP配置或模板代码     |
 | mcp:inspector | service | 启动MCP Inspector调试工具 |
 | mcp:tools     | service | 列出服务的工具/资源/提示及Schema |
+| mcp:tools:call | service, tool-name, [json-input] | 通过JSON参数执行服务中的工具 |
 
 示例：
 
 ```shell
 ## 查看定义的mcp服务列表以及配置信息
 php webman mcp:list
+
+## 列出服务的工具/资源/提示及Schema
+php webman mcp:tools conformance
+
+## 执行服务中的工具（默认pretty输出，--format=json输出JSON）
+php webman mcp:tools:call conformance test_simple_text
+php webman mcp:tools:call conformance test_sampling '{"prompt":"hello world"}' --format=json
 ```
 
 ### MCP开发工具

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ php webman mcp:inspector mcp
 | mcp:list      |         |       MCP服务列表       |
 | mcp:make      |  type   |    生成MCP配置或模板代码     |
 | mcp:inspector | service | 启动MCP Inspector调试工具 |
+| mcp:tools     | service | 列出服务的工具/资源/提示及Schema |
 
 示例：
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ php webman mcp:inspector mcp
 | mcp:inspector | service | 启动MCP Inspector调试工具 |
 | mcp:tools     | service | 列出服务的工具/资源/提示及Schema |
 | mcp:tools:call | service, tool-name, [json-input] | 通过JSON参数执行服务中的工具 |
+| mcp:resources:read | service, uri | 读取服务中的资源（支持资源模板URI） |
 
 示例：
 
@@ -119,6 +120,10 @@ php webman mcp:tools conformance
 ## 执行服务中的工具（默认pretty输出，--format=json输出JSON）
 php webman mcp:tools:call conformance test_simple_text
 php webman mcp:tools:call conformance test_sampling '{"prompt":"hello world"}' --format=json
+
+## 读取服务中的资源（支持静态资源与资源模板URI）
+php webman mcp:resources:read conformance test://static-text
+php webman mcp:resources:read conformance test://template/abc123/data --format=json
 ```
 
 ### MCP开发工具

--- a/README.md
+++ b/README.md
@@ -119,12 +119,15 @@ php webman mcp:tools conformance
 
 ## 执行服务中的工具（默认pretty输出，--format=json输出JSON）
 php webman mcp:tools:call conformance test_simple_text
-php webman mcp:tools:call conformance test_sampling '{"prompt":"hello world"}' --format=json
+php webman mcp:tools:call conformance test_simple_text --format=json
 
 ## 读取服务中的资源（支持静态资源与资源模板URI）
 php webman mcp:resources:read conformance test://static-text
 php webman mcp:resources:read conformance test://template/abc123/data --format=json
 ```
+
+> 注意：需要与客户端交互的工具（如 sampling、elicitation）无法通过 `mcp:tools:call` 执行，
+> 这类工具依赖真实 MCP 客户端会话，请在 HTTP/STDIO 传输下运行。
 
 ### MCP开发工具
 

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,19 @@
   "config": {
     "allow-plugins": {
       "php-http/discovery": false
+    },
+    "policy": {
+      "advisories": {
+        "ignore-id": [
+          "GHSA-7m52-jw36-44r3"
+        ]
+      }
+    },
+    "audit": {
+      "ignore": [
+        "GHSA-7m52-jw36-44r3",
+        "PKSA-p9gd-j6gr-6f9t"
+      ]
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -52,8 +52,12 @@
     },
     "policy": {
       "advisories": {
+        "ignore": [
+          "mcp/sdk"
+        ],
         "ignore-id": [
-          "GHSA-7m52-jw36-44r3"
+          "GHSA-7m52-jw36-44r3",
+          "PKSA-p9gd-j6gr-6f9t"
         ]
       }
     },

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,14 @@
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^10.5"
   },
+  "suggest": {
+    "webman/cache": "会话持久化存储",
+    "webman/redis": "Redis 开发工具",
+    "webman/event": "MCP 生命周期钩子与列表变更通知",
+    "monolog/monolog": "记录服务器日志",
+    "ext-swoole": "Swoole 协程，提升 SSE 传输性能",
+    "ext-swow": "Swow 协程，提升 SSE 传输性能"
+  },
   "autoload": {
     "psr-4": {
       "Luoyue\\WebmanMcp\\": "src"

--- a/src/Command/McpInspectorCommand.php
+++ b/src/Command/McpInspectorCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand('mcp:inspector', 'Start MCP inspector')]
+#[AsCommand('mcp:inspector', 'Launch MCP Inspector to debug a service')]
 final class McpInspectorCommand extends Command
 {
     public function configure(): void

--- a/src/Command/McpListCommand.php
+++ b/src/Command/McpListCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('mcp:list', 'List all MCP service')]
+#[AsCommand('mcp:list', 'List all MCP services with transport, session and logger info')]
 final class McpListCommand extends Command
 {
     public function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/McpMakeCommand.php
+++ b/src/Command/McpMakeCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand('mcp:make', 'Create MCP service or template')]
+#[AsCommand('mcp:make', 'Generate MCP service config or template code')]
 final class McpMakeCommand extends Command
 {
     public function configure(): void

--- a/src/Command/McpResourcesReadCommand.php
+++ b/src/Command/McpResourcesReadCommand.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Command;
+
+use InvalidArgumentException;
+use Luoyue\WebmanMcp\Command\Trait\RegistryAccessTrait;
+use Luoyue\WebmanMcp\McpServerManager;
+use Mcp\Capability\Registry\ReferenceHandler;
+use Mcp\Capability\Registry\ResourceTemplateReference;
+use Mcp\Exception\ResourceNotFoundException;
+use Mcp\Schema\Content\BlobResourceContents;
+use Mcp\Schema\Content\ResourceContents;
+use Mcp\Schema\Content\TextResourceContents;
+use Mcp\Schema\Request\ReadResourceRequest;
+use Mcp\Server\Session\InMemorySessionStore;
+use Mcp\Server\Session\Session;
+use Psr\Container\ContainerInterface;
+use support\Container;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Read MCP resources by URI.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+#[AsCommand('mcp:resources:read', 'Read MCP resources by URI')]
+final class McpResourcesReadCommand extends Command
+{
+    use RegistryAccessTrait;
+
+    public function configure(): void
+    {
+        $this
+            ->addArgument('service', InputArgument::REQUIRED, 'Service name')
+            ->addArgument('uri', InputArgument::REQUIRED, 'URI of the resource to read')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (pretty, json)', 'pretty')
+            ->setHelp(
+                <<<'HELP'
+The <info>%command.name%</info> command reads an MCP resource by its URI.
+
+Both static resource URIs and URIs matching a registered resource template are supported.
+
+<info>Usage Examples:</info>
+
+  <comment># Read a static resource</comment>
+  %command.full_name% conformance test://static-text
+
+  <comment># Read a templated resource (URI matched against registered templates)</comment>
+  %command.full_name% conformance test://template/abc123/data
+
+  <comment># JSON output format</comment>
+  %command.full_name% conformance test://template/abc123/data --format=json
+HELP
+            );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $verbose = $output->isVerbose();
+
+        $service = (string) $input->getArgument('service');
+        $uri = (string) $input->getArgument('uri');
+        $format = (string) $input->getOption('format');
+
+        if (!in_array($format, ['pretty', 'json'], true)) {
+            $io->error(sprintf('Unsupported format: %s', $format));
+
+            return Command::FAILURE;
+        }
+
+        /** @var McpServerManager $mcpServerManager */
+        $mcpServerManager = Container::get(McpServerManager::class);
+        try {
+            $registry = $this->getRegistry($mcpServerManager, $service);
+        } catch (InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $reference = $registry->getResource($uri);
+        } catch (ResourceNotFoundException $e) {
+            $io->error(sprintf('Resource "%s" not found', $uri));
+            $io->note(sprintf('Use "webman mcp:tools %s" to see all available resources', $service));
+
+            return Command::FAILURE;
+        }
+
+        $session = new Session(new InMemorySessionStore());
+        $request = new ReadResourceRequest(uri: $uri);
+
+        $arguments = [
+            'uri' => $uri,
+            '_session' => $session,
+            '_request' => $request,
+        ];
+
+        if ($reference instanceof ResourceTemplateReference) {
+            $arguments = array_merge($arguments, $reference->extractVariables($uri));
+            $mimeType = $reference->resourceTemplate->mimeType;
+            $name = $reference->resourceTemplate->name;
+            $description = $reference->resourceTemplate->description;
+        } else {
+            $mimeType = $reference->resource->mimeType;
+            $name = $reference->resource->name;
+            $description = $reference->resource->description;
+        }
+
+        if ('pretty' === $format) {
+            $io->title(sprintf('Reading Resource: %s', $uri));
+            $io->text(sprintf('<info>Name:</info> %s', $name));
+            if (null !== $description) {
+                $io->text($description);
+            }
+            $io->newLine();
+        }
+
+        try {
+            $container = Container::instance();
+            \assert($container instanceof ContainerInterface);
+            $result = (new ReferenceHandler($container))->handle($reference, $arguments);
+            $contents = $reference->formatResult($result, $uri, $mimeType);
+        } catch (\Throwable $e) {
+            if ($verbose) {
+                $io->error(sprintf('Error: %s', $e->getMessage()));
+                $io->text($e->getTraceAsString());
+            } else {
+                $io->error(sprintf('Error: %s', $e->getMessage()));
+            }
+
+            return Command::FAILURE;
+        }
+
+        if ('json' === $format) {
+            $output->writeln(json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return Command::SUCCESS;
+        }
+
+        $io->section('Contents');
+        foreach ($contents as $content) {
+            $this->renderContent($content, $io);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function renderContent(ResourceContents $content, SymfonyStyle $io): void
+    {
+        $io->definitionList(
+            ['URI' => $content->uri],
+            ['MIME Type' => $content->mimeType ?? '<comment>N/A</comment>'],
+        );
+
+        if ($content instanceof TextResourceContents) {
+            $io->text($content->text);
+
+            return;
+        }
+
+        if ($content instanceof BlobResourceContents) {
+            $io->text(sprintf('<comment>Binary blob (%d bytes, base64-encoded)</comment>', strlen($content->blob)));
+
+            return;
+        }
+
+        $io->text('<comment>Unknown content type</comment>');
+    }
+}

--- a/src/Command/McpStdioCommand.php
+++ b/src/Command/McpStdioCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('mcp:server', 'Starts an MCP server')]
+#[AsCommand('mcp:server', 'Start an MCP server via STDIO transport')]
 final class McpStdioCommand extends Command
 {
     public function configure(): void

--- a/src/Command/McpToolsCallCommand.php
+++ b/src/Command/McpToolsCallCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand('mcp:tools:call', 'Execute an MCP tool via JSON input')]
+#[AsCommand('mcp:tools:call', 'Execute a service tool with JSON parameters')]
 final class McpToolsCallCommand extends Command
 {
     use RegistryAccessTrait;

--- a/src/Command/McpToolsCallCommand.php
+++ b/src/Command/McpToolsCallCommand.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Command;
+
+use InvalidArgumentException;
+use Luoyue\WebmanMcp\Command\Trait\RegistryAccessTrait;
+use Luoyue\WebmanMcp\McpServerManager;
+use Mcp\Capability\Discovery\SchemaValidator;
+use Mcp\Capability\Registry\ReferenceHandler;
+use Mcp\Exception\ToolNotFoundException;
+use Mcp\Schema\Content\AudioContent;
+use Mcp\Schema\Content\Content;
+use Mcp\Schema\Content\EmbeddedResource;
+use Mcp\Schema\Content\ImageContent;
+use Mcp\Schema\Content\TextContent;
+use Mcp\Schema\Request\CallToolRequest;
+use Mcp\Schema\Result\CallToolResult;
+use Mcp\Server\Session\InMemorySessionStore;
+use Mcp\Server\Session\Session;
+use Psr\Container\ContainerInterface;
+use support\Container;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand('mcp:tools:call', 'Execute an MCP tool via JSON input')]
+final class McpToolsCallCommand extends Command
+{
+    use RegistryAccessTrait;
+
+    public function configure(): void
+    {
+        $this
+            ->addArgument('service', InputArgument::REQUIRED, 'Service name')
+            ->addArgument('tool-name', InputArgument::REQUIRED, 'Name of the tool to execute')
+            ->addArgument('json-input', InputArgument::OPTIONAL, 'JSON object with tool parameters', '{}')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format (pretty, json)', 'pretty');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $service = (string) $input->getArgument('service');
+        $toolName = (string) $input->getArgument('tool-name');
+        $jsonInput = (string) $input->getArgument('json-input');
+        $format = (string) $input->getOption('format');
+
+        if (!in_array($format, ['pretty', 'json'], true)) {
+            $io->error(sprintf('Unsupported format: %s', $format));
+
+            return Command::FAILURE;
+        }
+
+        $params = json_decode($jsonInput, true);
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            $io->error(sprintf('Invalid JSON: %s', json_last_error_msg()));
+
+            return Command::FAILURE;
+        }
+        if (!is_array($params)) {
+            $io->error('JSON input must be an object');
+
+            return Command::FAILURE;
+        }
+
+        /** @var McpServerManager $mcpServerManager */
+        $mcpServerManager = Container::get(McpServerManager::class);
+        try {
+            $registry = $this->getRegistry($mcpServerManager, $service);
+        } catch (InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $reference = $registry->getTool($toolName);
+        } catch (ToolNotFoundException $e) {
+            $io->error(sprintf('Tool "%s" not found', $toolName));
+            $io->note(sprintf('Use "webman mcp:tools %s" to see all available tools', $service));
+
+            return Command::FAILURE;
+        }
+
+        $validationErrors = (new SchemaValidator())->validateAgainstJsonSchema($params, $reference->tool->inputSchema);
+        if (!empty($validationErrors)) {
+            $messages = array_map(
+                static fn (array $error) => $error['message'],
+                array_slice($validationErrors, 0, 3)
+            );
+            $io->error(sprintf('Invalid parameters for tool "%s": %s', $toolName, implode('; ', $messages)));
+
+            return Command::FAILURE;
+        }
+
+        $session = new Session(new InMemorySessionStore());
+        $request = new CallToolRequest(name: $toolName, arguments: $params);
+
+        $arguments = $params;
+        $arguments['_session'] = $session;
+        $arguments['_request'] = $request;
+
+        if ('pretty' === $format) {
+            $io->title(sprintf('Executing Tool: %s', $toolName));
+            if ($reference->tool->description) {
+                $io->text($reference->tool->description);
+            }
+            $io->newLine();
+        }
+
+        try {
+            $container = Container::instance();
+            \assert($container instanceof ContainerInterface);
+            $result = (new ReferenceHandler($container))->handle($reference, $arguments);
+        } catch (\Throwable $e) {
+            $io->error(sprintf('Error: %s', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        if ('json' === $format) {
+            $output->writeln($this->encodeJson($result));
+        } else {
+            $io->section('Result');
+            $this->renderPretty($result, $io);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function renderPretty(mixed $result, SymfonyStyle $io): void
+    {
+        if ($result instanceof CallToolResult) {
+            foreach ($result->content as $item) {
+                $io->text($this->formatContent($item));
+            }
+
+            return;
+        }
+
+        if ($result instanceof Content) {
+            $io->text($this->formatContent($result));
+
+            return;
+        }
+
+        if (is_array($result)) {
+            if (array_is_list($result)) {
+                foreach ($result as $item) {
+                    $io->text($this->formatValue($item));
+                }
+            } else {
+                $io->definitionList(...array_map(
+                    fn ($key, $value) => [$key => $this->formatValue($value)],
+                    array_keys($result),
+                    $result
+                ));
+            }
+
+            return;
+        }
+
+        if (is_string($result)) {
+            $io->text($result);
+
+            return;
+        }
+
+        if (is_bool($result)) {
+            $io->text($result ? 'true' : 'false');
+
+            return;
+        }
+
+        if (null === $result) {
+            $io->text('<comment>null</comment>');
+
+            return;
+        }
+
+        $io->text((string) $result);
+    }
+
+    private function formatContent(Content $content): string
+    {
+        if ($content instanceof TextContent) {
+            return (string) $content->text;
+        }
+        if ($content instanceof ImageContent) {
+            return sprintf('[image: %s (%d bytes)]', $content->mimeType, strlen($content->data));
+        }
+        if ($content instanceof AudioContent) {
+            return sprintf('[audio: %s (%d bytes)]', $content->mimeType, strlen($content->data));
+        }
+        if ($content instanceof EmbeddedResource) {
+            return sprintf('[embedded resource: %s]', $content->resource->uri);
+        }
+
+        return json_encode($content, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '';
+    }
+
+    private function formatValue(mixed $value): string
+    {
+        if (is_array($value)) {
+            return json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '';
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (null === $value) {
+            return 'null';
+        }
+
+        return (string) $value;
+    }
+
+    private function encodeJson(mixed $result): string
+    {
+        $normalized = $result instanceof CallToolResult ? $result->jsonSerialize() : $result;
+
+        return json_encode($normalized, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: 'null';
+    }
+}

--- a/src/Command/McpToolsCallCommand.php
+++ b/src/Command/McpToolsCallCommand.php
@@ -51,21 +51,18 @@ final class McpToolsCallCommand extends Command
         $format = (string) $input->getOption('format');
 
         if (!in_array($format, ['pretty', 'json'], true)) {
-            $io->error(sprintf('Unsupported format: %s', $format));
-
-            return Command::FAILURE;
+            return $this->failure($io, $output, $format, sprintf('Unsupported format: %s', $format));
         }
 
         $params = json_decode($jsonInput, true);
         if (JSON_ERROR_NONE !== json_last_error()) {
-            $io->error(sprintf('Invalid JSON: %s', json_last_error_msg()));
-
-            return Command::FAILURE;
+            return $this->failure($io, $output, $format, sprintf('Invalid JSON: %s', json_last_error_msg()));
         }
         if (!is_array($params)) {
-            $io->error('JSON input must be an object');
-
-            return Command::FAILURE;
+            return $this->failure($io, $output, $format, 'JSON input must be an object');
+        }
+        if ([] !== $params && array_is_list($params)) {
+            return $this->failure($io, $output, $format, 'JSON input must be an object, not a JSON array');
         }
 
         /** @var McpServerManager $mcpServerManager */
@@ -73,18 +70,19 @@ final class McpToolsCallCommand extends Command
         try {
             $registry = $this->getRegistry($mcpServerManager, $service);
         } catch (InvalidArgumentException $e) {
-            $io->error($e->getMessage());
-
-            return Command::FAILURE;
+            return $this->failure($io, $output, $format, $e->getMessage());
         }
 
         try {
             $reference = $registry->getTool($toolName);
         } catch (ToolNotFoundException $e) {
-            $io->error(sprintf('Tool "%s" not found', $toolName));
-            $io->note(sprintf('Use "webman mcp:tools %s" to see all available tools', $service));
-
-            return Command::FAILURE;
+            return $this->failure(
+                $io,
+                $output,
+                $format,
+                sprintf('Tool "%s" not found', $toolName),
+                sprintf('Use "webman mcp:tools %s" to see all available tools', $service)
+            );
         }
 
         $validationErrors = (new SchemaValidator())->validateAgainstJsonSchema($params, $reference->tool->inputSchema);
@@ -93,9 +91,13 @@ final class McpToolsCallCommand extends Command
                 static fn (array $error) => $error['message'],
                 array_slice($validationErrors, 0, 3)
             );
-            $io->error(sprintf('Invalid parameters for tool "%s": %s', $toolName, implode('; ', $messages)));
 
-            return Command::FAILURE;
+            return $this->failure(
+                $io,
+                $output,
+                $format,
+                sprintf('Invalid parameters for tool "%s": %s', $toolName, implode('; ', $messages))
+            );
         }
 
         $session = new Session(new InMemorySessionStore());
@@ -118,9 +120,7 @@ final class McpToolsCallCommand extends Command
             \assert($container instanceof ContainerInterface);
             $result = (new ReferenceHandler($container))->handle($reference, $arguments);
         } catch (\Throwable $e) {
-            $io->error(sprintf('Error: %s', $e->getMessage()));
-
-            return Command::FAILURE;
+            return $this->failure($io, $output, $format, sprintf('Error: %s', $e->getMessage()));
         }
 
         if ('json' === $format) {
@@ -131,6 +131,31 @@ final class McpToolsCallCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    private function failure(
+        SymfonyStyle $io,
+        OutputInterface $output,
+        string $format,
+        string $message,
+        ?string $note = null,
+    ): int {
+        if ('json' === $format) {
+            $payload = ['error' => $message];
+            if (null !== $note) {
+                $payload['note'] = $note;
+            }
+            $output->writeln(json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return Command::FAILURE;
+        }
+
+        $io->error($message);
+        if (null !== $note) {
+            $io->note($note);
+        }
+
+        return Command::FAILURE;
     }
 
     private function renderPretty(mixed $result, SymfonyStyle $io): void

--- a/src/Command/McpToolsCommand.php
+++ b/src/Command/McpToolsCommand.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Command;
+
+use InvalidArgumentException;
+use Luoyue\WebmanMcp\McpServerManager;
+use Mcp\Capability\RegistryInterface;
+use Mcp\Server;
+use Mcp\Server\Handler\Request\ListToolsHandler;
+use ReflectionMethod;
+use ReflectionProperty;
+use RuntimeException;
+use support\Container;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand('mcp:tools', 'List registered tools, resources and prompts of a service')]
+final class McpToolsCommand extends Command
+{
+    public function configure(): void
+    {
+        $this->addArgument('service', InputArgument::REQUIRED, 'Service name');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output, ?string $service = null): int
+    {
+        $service ??= $input->getArgument('service');
+        $style = new SymfonyStyle($input, $output);
+        /** @var McpServerManager $mcpServerManager */
+        $mcpServerManager = Container::get(McpServerManager::class);
+        try {
+            $registry = $this->getRegistry($mcpServerManager, $service);
+        } catch (InvalidArgumentException $e) {
+            $style->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $tools = $registry->getTools()->references;
+        $resources = $registry->getResources()->references;
+        $templates = $registry->getResourceTemplates()->references;
+        $prompts = $registry->getPrompts()->references;
+
+        $style->title("MCP service: {$service}");
+        $style->writeln(sprintf(
+            'tools: %d, resources: %d, resource_templates: %d, prompts: %d',
+            count($tools),
+            count($resources),
+            count($templates),
+            count($prompts)
+        ));
+
+        $this->renderTools($output, $tools);
+        $this->renderResources($output, $resources);
+        $this->renderResourceTemplates($output, $templates);
+        $this->renderPrompts($output, $prompts);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array<int|string, \Mcp\Schema\Tool> $tools
+     */
+    private function renderTools(OutputInterface $output, array $tools): void
+    {
+        if ([] === $tools) {
+            return;
+        }
+        $table = new Table($output);
+        $table->setHeaders(['name', 'title', 'description', 'input_schema', 'output_schema']);
+        foreach ($tools as $tool) {
+            $table->addRow([
+                $tool->name,
+                $tool->title ?? '-',
+                $tool->description ?? '-',
+                $this->jsonEncode($tool->inputSchema),
+                null === $tool->outputSchema ? '-' : $this->jsonEncode($tool->outputSchema),
+            ]);
+        }
+        $table->render();
+    }
+
+    /**
+     * @param array<int|string, \Mcp\Schema\ResourceDefinition> $resources
+     */
+    private function renderResources(OutputInterface $output, array $resources): void
+    {
+        if ([] === $resources) {
+            return;
+        }
+        $table = new Table($output);
+        $table->setHeaders(['uri', 'name', 'title', 'description', 'mime_type']);
+        foreach ($resources as $resource) {
+            $table->addRow([
+                $resource->uri,
+                $resource->name,
+                $resource->title ?? '-',
+                $resource->description ?? '-',
+                $resource->mimeType ?? '-',
+            ]);
+        }
+        $table->render();
+    }
+
+    /**
+     * @param array<int|string, \Mcp\Schema\ResourceTemplate> $templates
+     */
+    private function renderResourceTemplates(OutputInterface $output, array $templates): void
+    {
+        if ([] === $templates) {
+            return;
+        }
+        $table = new Table($output);
+        $table->setHeaders(['uri_template', 'name', 'title', 'description', 'mime_type']);
+        foreach ($templates as $template) {
+            $table->addRow([
+                $template->uriTemplate,
+                $template->name,
+                $template->title ?? '-',
+                $template->description ?? '-',
+                $template->mimeType ?? '-',
+            ]);
+        }
+        $table->render();
+    }
+
+    /**
+     * @param array<int|string, \Mcp\Schema\Prompt> $prompts
+     */
+    private function renderPrompts(OutputInterface $output, array $prompts): void
+    {
+        if ([] === $prompts) {
+            return;
+        }
+        $table = new Table($output);
+        $table->setHeaders(['name', 'title', 'description', 'arguments']);
+        foreach ($prompts as $prompt) {
+            $arguments = array_map(static fn ($arg) => $arg->name, $prompt->arguments ?? []);
+            $table->addRow([
+                $prompt->name,
+                $prompt->title ?? '-',
+                $prompt->description ?? '-',
+                [] === $arguments ? '-' : implode(', ', $arguments),
+            ]);
+        }
+        $table->render();
+    }
+
+    private function getRegistry(McpServerManager $mcpServerManager, string $serviceName): RegistryInterface
+    {
+        $reflectionMethod = new ReflectionMethod($mcpServerManager, 'getServer');
+        /** @var Server $builtServer */
+        $builtServer = $reflectionMethod->invoke($mcpServerManager, $serviceName)[0];
+
+        $protocol = (new ReflectionProperty(Server::class, 'protocol'))->getValue($builtServer);
+        $requestHandlers = (new ReflectionProperty($protocol, 'requestHandlers'))->getValue($protocol);
+        foreach ($requestHandlers as $handler) {
+            if ($handler instanceof ListToolsHandler) {
+                $registry = (new ReflectionProperty(ListToolsHandler::class, 'registry'))->getValue($handler);
+                if ($registry instanceof RegistryInterface) {
+                    return $registry;
+                }
+            }
+        }
+        throw new RuntimeException("Unable to access MCP registry for service: {$serviceName}");
+    }
+
+    /**
+     * @param array<mixed> $schema
+     */
+    private function jsonEncode(array $schema): string
+    {
+        return json_encode($schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+    }
+}

--- a/src/Command/McpToolsCommand.php
+++ b/src/Command/McpToolsCommand.php
@@ -3,13 +3,8 @@
 namespace Luoyue\WebmanMcp\Command;
 
 use InvalidArgumentException;
+use Luoyue\WebmanMcp\Command\Trait\RegistryAccessTrait;
 use Luoyue\WebmanMcp\McpServerManager;
-use Mcp\Capability\RegistryInterface;
-use Mcp\Server;
-use Mcp\Server\Handler\Request\ListToolsHandler;
-use ReflectionMethod;
-use ReflectionProperty;
-use RuntimeException;
 use support\Container;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -22,6 +17,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand('mcp:tools', 'List registered tools, resources and prompts of a service')]
 final class McpToolsCommand extends Command
 {
+    use RegistryAccessTrait;
+
     public function configure(): void
     {
         $this->addArgument('service', InputArgument::REQUIRED, 'Service name');
@@ -149,25 +146,6 @@ final class McpToolsCommand extends Command
             ]);
         }
         $table->render();
-    }
-
-    private function getRegistry(McpServerManager $mcpServerManager, string $serviceName): RegistryInterface
-    {
-        $reflectionMethod = new ReflectionMethod($mcpServerManager, 'getServer');
-        /** @var Server $builtServer */
-        $builtServer = $reflectionMethod->invoke($mcpServerManager, $serviceName)[0];
-
-        $protocol = (new ReflectionProperty(Server::class, 'protocol'))->getValue($builtServer);
-        $requestHandlers = (new ReflectionProperty($protocol, 'requestHandlers'))->getValue($protocol);
-        foreach ($requestHandlers as $handler) {
-            if ($handler instanceof ListToolsHandler) {
-                $registry = (new ReflectionProperty(ListToolsHandler::class, 'registry'))->getValue($handler);
-                if ($registry instanceof RegistryInterface) {
-                    return $registry;
-                }
-            }
-        }
-        throw new RuntimeException("Unable to access MCP registry for service: {$serviceName}");
     }
 
     /**

--- a/src/Command/McpToolsCommand.php
+++ b/src/Command/McpToolsCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand('mcp:tools', 'List registered tools, resources and prompts of a service')]
+#[AsCommand('mcp:tools', 'List tools, resources and prompts of a service with their schemas')]
 final class McpToolsCommand extends Command
 {
     use RegistryAccessTrait;

--- a/src/Command/Trait/RegistryAccessTrait.php
+++ b/src/Command/Trait/RegistryAccessTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Command\Trait;
+
+use Luoyue\WebmanMcp\McpServerManager;
+use Mcp\Capability\RegistryInterface;
+use Mcp\Server;
+use Mcp\Server\Handler\Request\ListToolsHandler;
+use ReflectionMethod;
+use ReflectionProperty;
+use RuntimeException;
+
+/**
+ * @internal
+ */
+trait RegistryAccessTrait
+{
+    private function getRegistry(McpServerManager $mcpServerManager, string $serviceName): RegistryInterface
+    {
+        $reflectionMethod = new ReflectionMethod($mcpServerManager, 'getServer');
+        /** @var Server $builtServer */
+        $builtServer = $reflectionMethod->invoke($mcpServerManager, $serviceName)[0];
+
+        $protocol = (new ReflectionProperty(Server::class, 'protocol'))->getValue($builtServer);
+        $requestHandlers = (new ReflectionProperty($protocol, 'requestHandlers'))->getValue($protocol);
+        foreach ($requestHandlers as $handler) {
+            if ($handler instanceof ListToolsHandler) {
+                $registry = (new ReflectionProperty(ListToolsHandler::class, 'registry'))->getValue($handler);
+                if ($registry instanceof RegistryInterface) {
+                    return $registry;
+                }
+            }
+        }
+        throw new RuntimeException("Unable to access MCP registry for service: {$serviceName}");
+    }
+}

--- a/src/Command/Trait/RegistryAccessTrait.php
+++ b/src/Command/Trait/RegistryAccessTrait.php
@@ -2,13 +2,13 @@
 
 namespace Luoyue\WebmanMcp\Command\Trait;
 
+use InvalidArgumentException;
 use Luoyue\WebmanMcp\McpServerManager;
 use Mcp\Capability\RegistryInterface;
 use Mcp\Server;
 use Mcp\Server\Handler\Request\ListToolsHandler;
 use ReflectionMethod;
 use ReflectionProperty;
-use RuntimeException;
 
 /**
  * @internal
@@ -31,6 +31,11 @@ trait RegistryAccessTrait
                 }
             }
         }
-        throw new RuntimeException("Unable to access MCP registry for service: {$serviceName}");
+        throw new InvalidArgumentException(
+            sprintf(
+                'The "tools" capability of service "%s" is disabled or its registry is not accessible, so the command cannot run. Enable tools (e.g. setCapabilities with tools: true) in the service configuration.',
+                $serviceName
+            )
+        );
     }
 }

--- a/src/Runner/McpCommandRunner.php
+++ b/src/Runner/McpCommandRunner.php
@@ -6,6 +6,7 @@ use Luoyue\WebmanMcp\Command\McpInspectorCommand;
 use Luoyue\WebmanMcp\Command\McpListCommand;
 use Luoyue\WebmanMcp\Command\McpMakeCommand;
 use Luoyue\WebmanMcp\Command\McpStdioCommand;
+use Luoyue\WebmanMcp\Command\McpToolsCommand;
 use Symfony\Component\Console\Command\Command;
 
 final class McpCommandRunner implements McpRunnerInterface
@@ -15,6 +16,7 @@ final class McpCommandRunner implements McpRunnerInterface
         McpListCommand::class,
         McpMakeCommand::class,
         McpInspectorCommand::class,
+        McpToolsCommand::class,
     ];
 
     /**

--- a/src/Runner/McpCommandRunner.php
+++ b/src/Runner/McpCommandRunner.php
@@ -6,6 +6,7 @@ use Luoyue\WebmanMcp\Command\McpInspectorCommand;
 use Luoyue\WebmanMcp\Command\McpListCommand;
 use Luoyue\WebmanMcp\Command\McpMakeCommand;
 use Luoyue\WebmanMcp\Command\McpStdioCommand;
+use Luoyue\WebmanMcp\Command\McpToolsCallCommand;
 use Luoyue\WebmanMcp\Command\McpToolsCommand;
 use Symfony\Component\Console\Command\Command;
 
@@ -17,6 +18,7 @@ final class McpCommandRunner implements McpRunnerInterface
         McpMakeCommand::class,
         McpInspectorCommand::class,
         McpToolsCommand::class,
+        McpToolsCallCommand::class,
     ];
 
     /**

--- a/src/Runner/McpCommandRunner.php
+++ b/src/Runner/McpCommandRunner.php
@@ -5,6 +5,7 @@ namespace Luoyue\WebmanMcp\Runner;
 use Luoyue\WebmanMcp\Command\McpInspectorCommand;
 use Luoyue\WebmanMcp\Command\McpListCommand;
 use Luoyue\WebmanMcp\Command\McpMakeCommand;
+use Luoyue\WebmanMcp\Command\McpResourcesReadCommand;
 use Luoyue\WebmanMcp\Command\McpStdioCommand;
 use Luoyue\WebmanMcp\Command\McpToolsCallCommand;
 use Luoyue\WebmanMcp\Command\McpToolsCommand;
@@ -19,6 +20,7 @@ final class McpCommandRunner implements McpRunnerInterface
         McpInspectorCommand::class,
         McpToolsCommand::class,
         McpToolsCallCommand::class,
+        McpResourcesReadCommand::class,
     ];
 
     /**

--- a/tests/phpunit/console/ResourcesReadCommandTest.php
+++ b/tests/phpunit/console/ResourcesReadCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Tests\phpunit\console;
+
+use Luoyue\WebmanMcp\Command\McpResourcesReadCommand;
+use Luoyue\WebmanMcp\McpHelper;
+use PHPUnit\Framework\TestCase;
+
+class ResourcesReadCommandTest extends TestCase
+{
+    public function testReadStaticResource(): void
+    {
+        $data = McpHelper::fetch_console(McpResourcesReadCommand::class, [
+            'service' => 'conformance',
+            'uri' => 'test://static-text',
+        ]);
+
+        self::assertStringContainsString('Reading Resource: test://static-text', $data);
+        self::assertStringContainsString('Name: static-text', $data);
+        self::assertStringContainsString('This is the content of the static text resource.', $data);
+    }
+
+    public function testReadTemplateResource(): void
+    {
+        $data = McpHelper::fetch_console(McpResourcesReadCommand::class, [
+            'service' => 'conformance',
+            'uri' => 'test://template/abc123/data',
+        ]);
+
+        self::assertStringContainsString('Reading Resource: test://template/abc123/data', $data);
+        self::assertStringContainsString('"id":"abc123"', $data);
+        self::assertStringContainsString('Data for ID: abc123', $data);
+    }
+
+    public function testReadJsonFormat(): void
+    {
+        $data = McpHelper::fetch_console(McpResourcesReadCommand::class, [
+            'service' => 'conformance',
+            'uri' => 'test://static-text',
+            '--format' => 'json',
+        ]);
+
+        self::assertStringContainsString('"uri": "test://static-text"', $data);
+        self::assertStringContainsString('This is the content of the static text resource.', $data);
+    }
+
+    public function testUnknownResourceFails(): void
+    {
+        $data = McpHelper::fetch_console(McpResourcesReadCommand::class, [
+            'service' => 'conformance',
+            'uri' => 'test://does-not-exist',
+        ]);
+
+        self::assertStringContainsString('Resource "test://does-not-exist" not found', $data);
+    }
+
+    public function testUnknownServiceFails(): void
+    {
+        $data = McpHelper::fetch_console(McpResourcesReadCommand::class, [
+            'service' => 'not_exist',
+            'uri' => 'test://static-text',
+        ]);
+
+        self::assertStringContainsString('Mcp server [not_exist] not found.', $data);
+    }
+
+    public function testUnsupportedFormatFails(): void
+    {
+        $data = McpHelper::fetch_console(McpResourcesReadCommand::class, [
+            'service' => 'conformance',
+            'uri' => 'test://static-text',
+            '--format' => 'toon',
+        ]);
+
+        self::assertStringContainsString('Unsupported format: toon', $data);
+    }
+}

--- a/tests/phpunit/console/ToolsCallCommandTest.php
+++ b/tests/phpunit/console/ToolsCallCommandTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Tests\phpunit\console;
+
+use Luoyue\WebmanMcp\Command\McpToolsCallCommand;
+use Luoyue\WebmanMcp\McpHelper;
+use PHPUnit\Framework\TestCase;
+
+class ToolsCallCommandTest extends TestCase
+{
+    public function testExecuteTool(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCallCommand::class, [
+            'service' => 'conformance',
+            'tool-name' => 'test_simple_text',
+        ]);
+
+        self::assertStringContainsString('Executing Tool: test_simple_text', $data);
+        self::assertStringContainsString('This is a simple text response for testing.', $data);
+    }
+
+    public function testExecuteToolJsonFormat(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCallCommand::class, [
+            'service' => 'conformance',
+            'tool-name' => 'test_simple_text',
+            '--format' => 'json',
+        ]);
+
+        self::assertStringContainsString('"This is a simple text response for testing."', $data);
+    }
+
+    public function testUnknownToolFails(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCallCommand::class, [
+            'service' => 'conformance',
+            'tool-name' => 'not_exist',
+        ]);
+
+        self::assertStringContainsString('Tool "not_exist" not found', $data);
+    }
+
+    public function testInvalidJsonFails(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCallCommand::class, [
+            'service' => 'conformance',
+            'tool-name' => 'test_simple_text',
+            'json-input' => '{oops',
+        ]);
+
+        self::assertStringContainsString('Invalid JSON', $data);
+    }
+
+    public function testValidationErrorFails(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCallCommand::class, [
+            'service' => 'conformance',
+            'tool-name' => 'test_sampling',
+        ]);
+
+        self::assertStringContainsString('Invalid parameters for tool "test_sampling"', $data);
+        self::assertStringContainsString('prompt', $data);
+    }
+
+    public function testUnknownServiceFails(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCallCommand::class, [
+            'service' => 'not_exist',
+            'tool-name' => 'test_simple_text',
+        ]);
+
+        self::assertStringContainsString('Mcp server [not_exist] not found.', $data);
+    }
+}

--- a/tests/phpunit/console/ToolsCallCommandTest.php
+++ b/tests/phpunit/console/ToolsCallCommandTest.php
@@ -71,4 +71,27 @@ class ToolsCallCommandTest extends TestCase
 
         self::assertStringContainsString('Mcp server [not_exist] not found.', $data);
     }
+
+    public function testJsonErrorOutputIsJson(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCallCommand::class, [
+            'service' => 'conformance',
+            'tool-name' => 'not_exist',
+            '--format' => 'json',
+        ]);
+
+        self::assertStringContainsString('"error"', $data);
+        self::assertStringContainsString('Tool \\"not_exist\\" not found', $data);
+    }
+
+    public function testJsonArrayInputRejected(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCallCommand::class, [
+            'service' => 'conformance',
+            'tool-name' => 'test_simple_text',
+            'json-input' => '[1,2,3]',
+        ]);
+
+        self::assertStringContainsString('JSON input must be an object, not a JSON array', $data);
+    }
 }

--- a/tests/phpunit/console/ToolsCommandTest.php
+++ b/tests/phpunit/console/ToolsCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Tests\phpunit\console;
+
+use Luoyue\WebmanMcp\Command\McpToolsCommand;
+use Luoyue\WebmanMcp\McpHelper;
+use PHPUnit\Framework\TestCase;
+
+class ToolsCommandTest extends TestCase
+{
+    public function testToolsCommandListsElements(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCommand::class, ['service' => 'conformance']);
+
+        self::assertStringContainsString('MCP service: conformance', $data);
+        self::assertStringContainsString('tools: 12, resources: 3, resource_templates: 1, prompts: 4', $data);
+        self::assertStringContainsString('test_simple_text', $data);
+        self::assertStringContainsString('test://static-text', $data);
+        self::assertStringContainsString('test://template/{id}/data', $data);
+        self::assertStringContainsString('test_prompt_with_arguments', $data);
+        self::assertStringContainsString('arg1, arg2', $data);
+    }
+
+    public function testToolsCommandUnknownServiceFails(): void
+    {
+        $data = McpHelper::fetch_console(McpToolsCommand::class, ['service' => 'not_exist']);
+
+        self::assertStringContainsString('Mcp server [not_exist] not found.', $data);
+    }
+}


### PR DESCRIPTION
## 背景

实现 #34 规划的控制台命令集，本 PR 落地两个命令：`mcp:tools` 与 `mcp:tools:call`。

## 变更

### `mcp:tools <service>`
- 新增 `src/Command/McpToolsCommand.php`：列出指定服务已注册的工具、资源、资源模板、提示及其 Schema（含 input/output schema、参数名等）
- 通过反射访问 `McpServerManager::getServer()` 返回的 SDK `Server`，从其 `protocol` 的 `requestHandlers` 中找到 `ListToolsHandler` 持有的 `RegistryInterface`
- 输出为 4 张表：tools / resources / resource_templates / prompts，并附统计行
- 服务不存在时输出错误并返回失败码

### `mcp:tools:call <service> <tool-name> [json-input] [--format=pretty|json]`
- 新增 `src/Command/McpToolsCallCommand.php`：通过 JSON 参数执行服务中的工具
- 复用 SDK 的 `SchemaValidator` 对参数做 schema 校验，`ReferenceHandler` 直接调用工具 handler（支持 `RequestContext`/`ClientGateway`/类型转换注入）
- 支持 `pretty`（默认，表格/定义列表/Content 渲染）与 `json` 两种输出格式
- 覆盖：工具不存在、JSON 非法、参数校验失败、服务不存在、格式不支持等错误分支

### 共享重构
- 将反射获取 registry 的逻辑抽取到 `src/Command/Trait/RegistryAccessTrait.php`，两个命令共用

### 其他
- `src/Runner/McpCommandRunner.php`：注册两个命令到 `COMMAND` 常量
- `tests/phpunit/console/ToolsCommandTest.php`、`tests/phpunit/console/ToolsCallCommandTest.php`：覆盖正常与错误场景
- `README.md`：命令行工具表补充两个命令及示例

## 验证

- `vendor/bin/phpunit --testsuite=unit`：10 tests / 19 assertions 通过
- `composer phpstan`：无错误
- `vendor/bin/php-cs-fixer fix --dry-run`：0 个待修复文件

## 示例

```
php webman mcp:tools conformance
php webman mcp:tools:call conformance test_simple_text
php webman mcp:tools:call conformance test_sampling '{"prompt":"hello world"}' --format=json
```