### PR TITLE
升级 mcp/sdk 至 ^0.7 并移除安全通告忽略配置

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "description": "Webman plugin luoyue/webman-mcp",
   "require": {
     "php": ">=8.1",
-    "mcp/sdk": "^0.6",
+    "mcp/sdk": "^0.7",
     "nyholm/psr7": "^1.8",
     "webman/console": "^2.1.12"
   },
@@ -49,23 +49,6 @@
   "config": {
     "allow-plugins": {
       "php-http/discovery": false
-    },
-    "policy": {
-      "advisories": {
-        "ignore": [
-          "mcp/sdk"
-        ],
-        "ignore-id": [
-          "GHSA-7m52-jw36-44r3",
-          "PKSA-p9gd-j6gr-6f9t"
-        ]
-      }
-    },
-    "audit": {
-      "ignore": [
-        "GHSA-7m52-jw36-44r3",
-        "PKSA-p9gd-j6gr-6f9t"
-      ]
     }
   }
 }


### PR DESCRIPTION
## 背景

`mcp/sdk v0.6.0` 命中安全通告 `GHSA-7m52-jw36-44r3`（Cross-Client Data Leak via Shared Server/Transport Instance Reuse），而该通告的修复版本为 v0.7.0 / v0.7.1。

上一个 PR（#38）曾通过在 `composer.json` 中配置 `policy.advisories.ignore-id` 与 `audit.ignore` 临时忽略该通告以让 CI 通过。

## 变更

- `composer.json`：`mcp/sdk` 依赖约束 `^0.6` → `^0.7`
- `composer.json`：移除 `config.policy.advisories.*` 与 `config.audit.ignore` 忽略配置（升级后不再需要）

> 注：`composer.lock` 本仓库按库项目惯例忽略，不提交。

## 验证

- `composer update mcp/sdk`：v0.6.0 → v0.7.1，无安全通告
- `vendor/bin/phpunit --testsuite=unit`：OK（18 tests / 33 assertions）
- `composer phpstan`：无错误
- `composer cs:check`：0 个待修复文件