### PR TITLE
test: DevMcp 单元测试 + GitHub Actions MySQL/Redis 服务适配

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,6 +71,37 @@ jobs:
       matrix:
         php: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
         dependencies: [ 'lowest', 'highest' ]
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: webman_mcp_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      MCP_TEST_DB_HOST: 127.0.0.1
+      MCP_TEST_DB_PORT: 3306
+      MCP_TEST_DB_DATABASE: webman_mcp_test
+      MCP_TEST_DB_USERNAME: root
+      MCP_TEST_DB_PASSWORD: root
+      MCP_TEST_REDIS_HOST: 127.0.0.1
+      MCP_TEST_REDIS_PORT: 6379
+      MCP_TEST_REDIS_DATABASE: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -79,6 +110,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: pdo_mysql, redis
 
       - name: Install Composer
         uses: ramsey/composer-install@v4

--- a/src/Server/DevelopmentMcpLoader.php
+++ b/src/Server/DevelopmentMcpLoader.php
@@ -2,12 +2,10 @@
 
 namespace Luoyue\WebmanMcp\Server;
 
-use Luoyue\WebmanMcp\McpServerManager;
 use Mcp\Capability\Discovery\Discoverer;
 use Mcp\Capability\Registry\Loader\DiscoveryLoader;
 use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Capability\RegistryInterface;
-use support\Log;
 
 class DevelopmentMcpLoader implements LoaderInterface
 {
@@ -20,18 +18,15 @@ class DevelopmentMcpLoader implements LoaderInterface
         private readonly array $path = [],
         ?string $basePath = null,
     ) {
-        $logger = Log::channel(McpServerManager::PLUGIN_REWFIX . 'mcp_error_stderr');
-
         $discoverer = class_exists(\Webman\Finder\Finder::class)
-            ? new WebmanDiscoverer($logger)
-            : new Discoverer($logger);
+            ? new WebmanDiscoverer()
+            : new Discoverer();
 
         $this->loader = new DiscoveryLoader(
             $basePath ?? base_path(),
             ['vendor/luoyue/webman-mcp/src/DevMcp', ...$this->path],
             [],
             $discoverer,
-            logger: $logger,
         );
     }
 

--- a/src/Server/DevelopmentMcpLoader.php
+++ b/src/Server/DevelopmentMcpLoader.php
@@ -2,36 +2,41 @@
 
 namespace Luoyue\WebmanMcp\Server;
 
+use Luoyue\WebmanMcp\McpServerManager;
 use Mcp\Capability\Discovery\Discoverer;
+use Mcp\Capability\Registry\Loader\DiscoveryLoader;
 use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Capability\RegistryInterface;
 use support\Log;
 
 class DevelopmentMcpLoader implements LoaderInterface
 {
+    private DiscoveryLoader $loader;
+
     /**
      * @param string[] $path
      */
-    public function __construct(private readonly array $path = [])
-    {
+    public function __construct(
+        private readonly array $path = [],
+        ?string $basePath = null,
+    ) {
+        $logger = Log::channel(McpServerManager::PLUGIN_REWFIX . 'mcp_error_stderr');
+
+        $discoverer = class_exists(\Webman\Finder\Finder::class)
+            ? new WebmanDiscoverer($logger)
+            : new Discoverer($logger);
+
+        $this->loader = new DiscoveryLoader(
+            $basePath ?? base_path(),
+            ['vendor/luoyue/webman-mcp/src/DevMcp', ...$this->path],
+            [],
+            $discoverer,
+            logger: $logger,
+        );
     }
 
     public function load(RegistryInterface $registry): void
     {
-        $discoverer = new Discoverer(Log::channel('plugin.luoyue.webman-mcp.mcp_error_stderr'));
-
-        $state = $discoverer->discover(base_path(), ['vendor/luoyue/webman-mcp/src/DevMcp', ...$this->path], []);
-        foreach ($state->getTools() as $tool) {
-            $registry->registerTool($tool->tool, $tool->handler);
-        }
-        foreach ($state->getPrompts() as $prompt) {
-            $registry->registerPrompt($prompt->prompt, $prompt->handler, $prompt->completionProviders);
-        }
-        foreach ($state->getResources() as $resource) {
-            $registry->registerResource($resource->resource, $resource->handler);
-        }
-        foreach ($state->getResourceTemplates() as $resource) {
-            $registry->registerResourceTemplate($resource->resourceTemplate, $resource->handler, $resource->completionProviders);
-        }
+        $this->loader->load($registry);
     }
 }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -10,3 +10,21 @@ require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 Config::load(__DIR__ . '/config', ['container'], key: 'plugin.luoyue.webman-mcp');
 Config::load(__DIR__ . '/config', ['app', 'mcp', 'database', 'redis']);
+
+/**
+ * 清理 Webman\Finder 在测试期间产生的运行时缓存目录（仓库根 runtime/）。
+ */
+register_shutdown_function(static function (): void {
+    $runtime = runtime_path();
+    if (!is_dir($runtime)) {
+        return;
+    }
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($runtime, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $item) {
+        $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+    }
+    rmdir($runtime);
+});

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -9,4 +9,4 @@ defined('BASE_PATH') || define('BASE_PATH', __DIR__);
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 Config::load(__DIR__ . '/config', ['container'], key: 'plugin.luoyue.webman-mcp');
-Config::load(__DIR__ . '/config', ['app', 'mcp']);
+Config::load(__DIR__ . '/config', ['app', 'mcp', 'database', 'redis']);

--- a/tests/Fixtures/DevMcp/Hello.php
+++ b/tests/Fixtures/DevMcp/Hello.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Tests\Fixtures\DevMcp;
+
+use Mcp\Capability\Attribute\McpPrompt;
+use Mcp\Capability\Attribute\McpResource;
+use Mcp\Capability\Attribute\McpResourceTemplate;
+use Mcp\Capability\Attribute\McpTool;
+
+class Hello
+{
+    #[McpTool(
+        name: 'devmc_fixture_hello',
+        title: 'Fixture Hello Tool',
+        description: 'A fixture tool for testing the development loader.'
+    )]
+    public function hello(string $name): string
+    {
+        return 'Hello ' . $name;
+    }
+
+    #[McpResource(
+        uri: 'fixture://hello/static',
+        name: 'fixture_hello_resource',
+        title: 'Fixture Hello Resource',
+        description: 'A fixture resource for testing the development loader.'
+    )]
+    public function helloResource(): string
+    {
+        return 'resource content';
+    }
+
+    /**
+     * @return array<never>
+     */
+    #[McpPrompt(
+        name: 'fixture_hello_prompt',
+        title: 'Fixture Hello Prompt',
+        description: 'A fixture prompt for testing the development loader.'
+    )]
+    public function helloPrompt(string $question): array
+    {
+        return [];
+    }
+
+    #[McpResourceTemplate(
+        uriTemplate: 'fixture://hello/{user}',
+        name: 'fixture_hello_template',
+        title: 'Fixture Hello Template',
+        description: 'A fixture resource template for testing the development loader.'
+    )]
+    public function helloTemplate(): string
+    {
+        return 'template content';
+    }
+}

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -1,0 +1,36 @@
+<?php
+
+$host = getenv('MCP_TEST_DB_HOST') ?: '127.0.0.1';
+$port = getenv('MCP_TEST_DB_PORT') ?: '3306';
+$database = getenv('MCP_TEST_DB_DATABASE') ?: 'webman_mcp_test';
+$username = getenv('MCP_TEST_DB_USERNAME') ?: 'root';
+$password = getenv('MCP_TEST_DB_PASSWORD') ?: 'root';
+
+return [
+    'default' => 'mysql',
+    'connections' => [
+        'mysql' => [
+            'driver' => 'mysql',
+            'host' => $host,
+            'port' => $port,
+            'database' => $database,
+            'username' => $username,
+            'password' => $password,
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_general_ci',
+            'prefix' => '',
+            'strict' => true,
+            'engine' => null,
+            'options' => [
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ],
+            'pool' => [
+                'max_connections' => 5,
+                'min_connections' => 1,
+                'wait_timeout' => 3,
+                'idle_timeout' => 60,
+                'heartbeat_interval' => 50,
+            ],
+        ],
+    ],
+];

--- a/tests/config/log.php
+++ b/tests/config/log.php
@@ -1,7 +1,0 @@
-<?php
-
-return [
-    'plugin.luoyue.webman-mcp.mcp_error_stderr' => [
-        'handlers' => [],
-    ],
-];

--- a/tests/config/log.php
+++ b/tests/config/log.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'plugin.luoyue.webman-mcp.mcp_error_stderr' => [
+        'handlers' => [],
+    ],
+];

--- a/tests/config/redis.php
+++ b/tests/config/redis.php
@@ -1,0 +1,22 @@
+<?php
+
+$host = getenv('MCP_TEST_REDIS_HOST') ?: '127.0.0.1';
+$port = (int) (getenv('MCP_TEST_REDIS_PORT') ?: '6379');
+$password = getenv('MCP_TEST_REDIS_PASSWORD') ?: '';
+$database = (int) (getenv('MCP_TEST_REDIS_DATABASE') ?: '0');
+
+return [
+    'default' => [
+        'host' => $host,
+        'port' => $port,
+        'password' => $password,
+        'database' => $database,
+        'pool' => [
+            'max_connections' => 5,
+            'min_connections' => 1,
+            'wait_timeout' => 3,
+            'idle_timeout' => 60,
+            'heartbeat_interval' => 50,
+        ],
+    ],
+];

--- a/tests/phpunit/devmcp/DatabaseTest.php
+++ b/tests/phpunit/devmcp/DatabaseTest.php
@@ -3,12 +3,22 @@
 namespace Luoyue\WebmanMcp\Tests\phpunit\devmcp;
 
 use Luoyue\WebmanMcp\DevMcp\Database;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use support\Db;
 
 class DatabaseTest extends TestCase
 {
-    private function connectionAvailable(): bool
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ('testDatabaseConnections' !== $this->name() && !$this->connectionAvailable()) {
+            self::markTestSkipped('MySQL 连接不可用，跳过');
+        }
+    }
+
+    protected function connectionAvailable(): bool
     {
         try {
             Db::connection()->getPdo();
@@ -36,12 +46,9 @@ class DatabaseTest extends TestCase
         self::assertArrayHasKey('max_connections', $first['pool']);
     }
 
+    #[RequiresPhpExtension('pdo_mysql')]
     public function testDatabaseExecuteSql(): void
     {
-        if (!$this->connectionAvailable()) {
-            self::markTestSkipped('MySQL 连接不可用，跳过');
-        }
-
         $db = new Database();
         $table = 'mcp_test_' . str_replace('.', '_', uniqid('', true));
 
@@ -58,12 +65,9 @@ class DatabaseTest extends TestCase
         }
     }
 
+    #[RequiresPhpExtension('pdo_mysql')]
     public function testDatabaseExecuteSqlSelectEmpty(): void
     {
-        if (!$this->connectionAvailable()) {
-            self::markTestSkipped('MySQL 连接不可用，跳过');
-        }
-
         $db = new Database();
         $table = 'mcp_test_' . str_replace('.', '_', uniqid('', true));
 
@@ -76,12 +80,9 @@ class DatabaseTest extends TestCase
         }
     }
 
+    #[RequiresPhpExtension('pdo_mysql')]
     public function testDatabaseExecuteSqlThrowsToolCallException(): void
     {
-        if (!$this->connectionAvailable()) {
-            self::markTestSkipped('MySQL 连接不可用，跳过');
-        }
-
         $db = new Database();
 
         $this->expectException(\Mcp\Exception\ToolCallException::class);

--- a/tests/phpunit/devmcp/DatabaseTest.php
+++ b/tests/phpunit/devmcp/DatabaseTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Tests\phpunit\devmcp;
+
+use Luoyue\WebmanMcp\DevMcp\Database;
+use PHPUnit\Framework\TestCase;
+use support\Db;
+
+class DatabaseTest extends TestCase
+{
+    private function connectionAvailable(): bool
+    {
+        try {
+            Db::connection()->getPdo();
+            return true;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    public function testDatabaseConnections(): void
+    {
+        $db = new Database();
+        $data = $db->databaseConnections();
+
+        self::assertArrayHasKey('default', $data);
+        self::assertArrayHasKey('connections', $data);
+        self::assertSame('plugin.luoyue.webman-mcp.mysql', $data['default']);
+        self::assertNotEmpty($data['connections']);
+
+        $first = $data['connections'][0];
+        self::assertSame('plugin.luoyue.webman-mcp.mysql', $first['connection_name']);
+        self::assertSame('mysql', $first['driver']);
+        self::assertSame('webman_mcp_test', $first['database']);
+        self::assertArrayHasKey('pool', $first);
+        self::assertArrayHasKey('max_connections', $first['pool']);
+    }
+
+    public function testDatabaseExecuteSql(): void
+    {
+        if (!$this->connectionAvailable()) {
+            self::markTestSkipped('MySQL 连接不可用，跳过');
+        }
+
+        $db = new Database();
+        $table = 'mcp_test_' . str_replace('.', '_', uniqid('', true));
+
+        Db::connection()->statement("CREATE TABLE `{$table}` (id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+        try {
+            Db::connection()->statement("INSERT INTO `{$table}` (`name`) VALUES ('lalala')");
+
+            $result = $db->databaseExecuteSql("SELECT `id`, `name` FROM `{$table}` WHERE `name` = :name", ['name' => 'lalala']);
+            self::assertCount(1, $result['result']);
+            self::assertSame('lalala', $result['result'][0]['name']);
+            self::assertArrayHasKey('id', $result['result'][0]);
+        } finally {
+            Db::connection()->statement("DROP TABLE IF EXISTS `{$table}`");
+        }
+    }
+
+    public function testDatabaseExecuteSqlSelectEmpty(): void
+    {
+        if (!$this->connectionAvailable()) {
+            self::markTestSkipped('MySQL 连接不可用，跳过');
+        }
+
+        $db = new Database();
+        $table = 'mcp_test_' . str_replace('.', '_', uniqid('', true));
+
+        Db::connection()->statement("CREATE TABLE `{$table}` (id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+        try {
+            $result = $db->databaseExecuteSql("SELECT `id` FROM `{$table}`", []);
+            self::assertSame([], $result['result']);
+        } finally {
+            Db::connection()->statement("DROP TABLE IF EXISTS `{$table}`");
+        }
+    }
+
+    public function testDatabaseExecuteSqlThrowsToolCallException(): void
+    {
+        if (!$this->connectionAvailable()) {
+            self::markTestSkipped('MySQL 连接不可用，跳过');
+        }
+
+        $db = new Database();
+
+        $this->expectException(\Mcp\Exception\ToolCallException::class);
+        $this->expectExceptionMessage('执行sql失败');
+        $db->databaseExecuteSql('SELECT * FROM `not_exists_table_xyz`', []);
+    }
+}

--- a/tests/phpunit/devmcp/RedisTest.php
+++ b/tests/phpunit/devmcp/RedisTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Tests\phpunit\devmcp;
+
+use Luoyue\WebmanMcp\DevMcp\Redis;
+use PHPUnit\Framework\TestCase;
+use support\Redis as RedisInstance;
+
+class RedisTest extends TestCase
+{
+    private const TEST_CONNECTION = 'plugin.luoyue.webman-mcp.default';
+
+    private function connectionAvailable(): bool
+    {
+        try {
+            RedisInstance::connection(self::TEST_CONNECTION)->ping();
+            return true;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    public function testDatabaseConnections(): void
+    {
+        $redis = new Redis();
+        $data = $redis->databaseConnections();
+
+        self::assertArrayHasKey('default', $data);
+        self::assertArrayHasKey('connections', $data);
+        self::assertSame('default', $data['default']);
+        self::assertNotEmpty($data['connections']);
+
+        $first = $data['connections'][0];
+        self::assertSame('plugin.luoyue.webman-mcp.default', $first['connection_name']);
+        self::assertSame(0, $first['database']);
+        self::assertNull($first['prefix']);
+        self::assertArrayHasKey('pool', $first);
+        self::assertArrayHasKey('max_connections', $first['pool']);
+    }
+
+    public function testExecuteRaw(): void
+    {
+        if (!$this->connectionAvailable()) {
+            self::markTestSkipped('Redis 连接不可用，跳过');
+        }
+
+        $redis = new Redis();
+        $key = 'mcp_test_' . str_replace('.', '', uniqid('', true));
+
+        try {
+            $set = $redis->executeRaw(['set', $key, 'value-01'], self::TEST_CONNECTION);
+            self::assertTrue($set['success']);
+            self::assertSame(true, $set['result']);
+
+            $get = $redis->executeRaw(['get', $key], self::TEST_CONNECTION);
+            self::assertTrue($get['success']);
+            self::assertSame('value-01', $get['result']);
+        } finally {
+            RedisInstance::connection(self::TEST_CONNECTION)->del([$key]);
+        }
+    }
+
+    public function testExecuteLua(): void
+    {
+        if (!$this->connectionAvailable()) {
+            self::markTestSkipped('Redis 连接不可用，跳过');
+        }
+
+        $redis = new Redis();
+        $key = 'mcp_test_' . str_replace('.', '', uniqid('', true));
+
+        try {
+            $result = $redis->executeLua(
+                'return {KEYS[1], ARGV[1], ARGV[2]}',
+                self::TEST_CONNECTION,
+                0,
+                1,
+                [$key, 'a1', 'b2']
+            );
+            self::assertSame([$key, 'a1', 'b2'], $result['result']);
+        } finally {
+            RedisInstance::connection(self::TEST_CONNECTION)->del([$key]);
+        }
+    }
+
+    public function testExecuteLuaSha(): void
+    {
+        if (!$this->connectionAvailable()) {
+            self::markTestSkipped('Redis 连接不可用，跳过');
+        }
+
+        $redis = new Redis();
+        $key = 'mcp_test_' . str_replace('.', '', uniqid('', true));
+        $script = 'return redis.call("GET", KEYS[1])';
+
+        try {
+            RedisInstance::connection(self::TEST_CONNECTION)->set($key, 'value-02');
+            $result = $redis->executeLuaSha(
+                $script,
+                self::TEST_CONNECTION,
+                0,
+                1,
+                [$key]
+            );
+            self::assertTrue($result['success']);
+            self::assertSame('value-02', $result['result']);
+        } finally {
+            RedisInstance::connection(self::TEST_CONNECTION)->del([$key]);
+        }
+    }
+}

--- a/tests/phpunit/devmcp/RedisTest.php
+++ b/tests/phpunit/devmcp/RedisTest.php
@@ -3,13 +3,23 @@
 namespace Luoyue\WebmanMcp\Tests\phpunit\devmcp;
 
 use Luoyue\WebmanMcp\DevMcp\Redis;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
 class RedisTest extends TestCase
 {
     private const TEST_CONNECTION = 'plugin.luoyue.webman-mcp.default';
 
-    private function connectionAvailable(): bool
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ('testDatabaseConnections' !== $this->name() && !$this->connectionAvailable()) {
+            self::markTestSkipped('Redis 连接不可用，跳过');
+        }
+    }
+
+    protected function connectionAvailable(): bool
     {
         try {
             $result = (new Redis())->executeRaw(['ping'], self::TEST_CONNECTION);
@@ -42,12 +52,9 @@ class RedisTest extends TestCase
         self::assertArrayHasKey('max_connections', $first['pool']);
     }
 
+    #[RequiresPhpExtension('redis')]
     public function testExecuteRaw(): void
     {
-        if (!$this->connectionAvailable()) {
-            self::markTestSkipped('Redis 连接不可用，跳过');
-        }
-
         $redis = new Redis();
         $key = 'mcp_test_' . str_replace('.', '', uniqid('', true));
 
@@ -64,12 +71,9 @@ class RedisTest extends TestCase
         }
     }
 
+    #[RequiresPhpExtension('redis')]
     public function testExecuteLua(): void
     {
-        if (!$this->connectionAvailable()) {
-            self::markTestSkipped('Redis 连接不可用，跳过');
-        }
-
         $redis = new Redis();
         $key = 'mcp_test_' . str_replace('.', '', uniqid('', true));
 
@@ -87,12 +91,9 @@ class RedisTest extends TestCase
         }
     }
 
+    #[RequiresPhpExtension('redis')]
     public function testExecuteLuaSha(): void
     {
-        if (!$this->connectionAvailable()) {
-            self::markTestSkipped('Redis 连接不可用，跳过');
-        }
-
         $redis = new Redis();
         $key = 'mcp_test_' . str_replace('.', '', uniqid('', true));
         $script = 'return redis.call("GET", KEYS[1])';

--- a/tests/phpunit/devmcp/RedisTest.php
+++ b/tests/phpunit/devmcp/RedisTest.php
@@ -4,7 +4,6 @@ namespace Luoyue\WebmanMcp\Tests\phpunit\devmcp;
 
 use Luoyue\WebmanMcp\DevMcp\Redis;
 use PHPUnit\Framework\TestCase;
-use support\Redis as RedisInstance;
 
 class RedisTest extends TestCase
 {
@@ -13,11 +12,16 @@ class RedisTest extends TestCase
     private function connectionAvailable(): bool
     {
         try {
-            RedisInstance::connection(self::TEST_CONNECTION)->ping();
-            return true;
+            $result = (new Redis())->executeRaw(['ping'], self::TEST_CONNECTION);
+            return $result['success'];
         } catch (\Throwable $e) {
             return false;
         }
+    }
+
+    private function deleteKeys(string ...$keys): void
+    {
+        (new Redis())->executeRaw(['del', ...$keys], self::TEST_CONNECTION);
     }
 
     public function testDatabaseConnections(): void
@@ -56,7 +60,7 @@ class RedisTest extends TestCase
             self::assertTrue($get['success']);
             self::assertSame('value-01', $get['result']);
         } finally {
-            RedisInstance::connection(self::TEST_CONNECTION)->del([$key]);
+            $this->deleteKeys($key);
         }
     }
 
@@ -79,7 +83,7 @@ class RedisTest extends TestCase
             );
             self::assertSame([$key, 'a1', 'b2'], $result['result']);
         } finally {
-            RedisInstance::connection(self::TEST_CONNECTION)->del([$key]);
+            $this->deleteKeys($key);
         }
     }
 
@@ -94,7 +98,7 @@ class RedisTest extends TestCase
         $script = 'return redis.call("GET", KEYS[1])';
 
         try {
-            RedisInstance::connection(self::TEST_CONNECTION)->set($key, 'value-02');
+            $redis->executeRaw(['set', $key, 'value-02'], self::TEST_CONNECTION);
             $result = $redis->executeLuaSha(
                 $script,
                 self::TEST_CONNECTION,
@@ -105,7 +109,7 @@ class RedisTest extends TestCase
             self::assertTrue($result['success']);
             self::assertSame('value-02', $result['result']);
         } finally {
-            RedisInstance::connection(self::TEST_CONNECTION)->del([$key]);
+            $this->deleteKeys($key);
         }
     }
 }

--- a/tests/phpunit/devmcp/SystemTest.php
+++ b/tests/phpunit/devmcp/SystemTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Tests\phpunit\devmcp;
+
+use Composer\InstalledVersions;
+use Luoyue\WebmanMcp\DevMcp\System;
+use PHPUnit\Framework\TestCase;
+use Workerman\Events\Select;
+use Workerman\Worker;
+
+class SystemTest extends TestCase
+{
+    public function testSystemInfo(): void
+    {
+        Worker::$globalEvent = new Select();
+        $info = (new System())->systemInfo();
+
+        self::assertSame(PHP_OS, $info['server_os']);
+        self::assertSame(PHP_VERSION, $info['php_version']);
+        self::assertSame(PHP_BINARY, $info['php_binary']);
+        self::assertSame(php_sapi_name(), $info['php_sapi_name']);
+        self::assertIsBool($info['is_coroutine']);
+        self::assertSame(sys_get_temp_dir(), $info['default_temp_dir']);
+        self::assertNotEquals('', $info['workerman_version']);
+        self::assertNotEquals('', $info['webman_version']);
+    }
+
+    public function testListDependence(): void
+    {
+        $data = (new System())->listDependence();
+
+        self::assertArrayHasKey('root', $data);
+        self::assertArrayHasKey('versions', $data);
+        self::assertSame('luoyue/webman-mcp', $data['root']['name']);
+        self::assertArrayHasKey('workerman/workerman', $data['versions']);
+    }
+
+    public function testExtensions(): void
+    {
+        $data = (new System())->extensions();
+
+        self::assertNotEmpty($data);
+        foreach (get_loaded_extensions() as $extension) {
+            self::assertArrayHasKey($extension, $data);
+        }
+    }
+
+    public function testGetPhpIni(): void
+    {
+        $data = (new System())->getPhpIni();
+
+        self::assertIsArray($data);
+        self::assertArrayHasKey('error_reporting', $data);
+
+        $filtered = (new System())->getPhpIni('date');
+        self::assertIsArray($filtered);
+        foreach (array_keys($filtered) as $key) {
+            self::assertStringContainsString('date', $key);
+        }
+    }
+
+    public function testGetConfig(): void
+    {
+        $system = new System();
+
+        self::assertSame(config('database.default'), $system->getConfig('database.default'));
+        self::assertSame(config('plugin.luoyue.webman-mcp.mcp.default_protocol'), $system->getConfig('plugin.luoyue.webman-mcp.mcp.default_protocol'));
+        self::assertSame(config('not_exists_key_abc'), $system->getConfig('not_exists_key_abc'));
+    }
+
+    public function testGetEnv(): void
+    {
+        self::assertSame(getenv('PATH'), (new System())->getEnv('PATH'));
+    }
+
+    public function testEvalCode(): void
+    {
+        $result = (new System())->evalCode('echo "hello-mcp";');
+
+        self::assertSame('hello-mcp', $result['result']);
+    }
+
+    public function testEvalCodeReturnsEmptyWhenNoOutput(): void
+    {
+        $result = (new System())->evalCode('');
+
+        self::assertSame('', $result['result']);
+    }
+
+    public function testEvalCodeRemovesPhpTags(): void
+    {
+        $result = (new System())->evalCode('<?php echo "world"; ?>');
+
+        self::assertSame('world', $result['result']);
+    }
+
+    public function testListRoutes(): void
+    {
+        $data = (new System())->listRoutes();
+
+        self::assertArrayHasKey('routes', $data);
+        self::assertIsArray($data['routes']);
+    }
+
+    public function testListEvents(): void
+    {
+        if (!InstalledVersions::isInstalled('webman/event')) {
+            self::markTestSkipped('webman/event not installed');
+        }
+
+        $data = (new System())->listEvents();
+
+        self::assertContainsOnly('array', $data);
+        foreach ($data as $item) {
+            self::assertArrayHasKey('event_name', $item);
+            self::assertArrayHasKey('callback', $item);
+        }
+    }
+}

--- a/tests/phpunit/server/DevelopmentMcpLoaderTest.php
+++ b/tests/phpunit/server/DevelopmentMcpLoaderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Luoyue\WebmanMcp\Tests\phpunit\server;
+
+use Luoyue\WebmanMcp\Server\DevelopmentMcpLoader;
+use Luoyue\WebmanMcp\Tests\Fixtures\DevMcp\Hello;
+use Mcp\Capability\Registry;
+use Mcp\Schema\Tool;
+use PHPUnit\Framework\TestCase;
+
+class DevelopmentMcpLoaderTest extends TestCase
+{
+    /**
+     * @param string[] $path
+     */
+    private function createLoader(array $path = []): DevelopmentMcpLoader
+    {
+        return new DevelopmentMcpLoader($path, dirname(__DIR__, 2));
+    }
+
+    public function testLoadRegistersDevMcpComponents(): void
+    {
+        $loader = $this->createLoader(['Fixtures/DevMcp']);
+        $registry = new Registry();
+        $loader->load($registry);
+
+        self::assertTrue($registry->hasTool('devmc_fixture_hello'));
+        self::assertTrue($registry->hasPrompt('fixture_hello_prompt'));
+        self::assertTrue($registry->hasResource('fixture://hello/static'));
+        self::assertTrue($registry->hasResourceTemplate('fixture://hello/{user}'));
+    }
+
+    public function testRegisteredHandlersPointToFixtureClass(): void
+    {
+        $loader = $this->createLoader(['Fixtures/DevMcp']);
+        $registry = new Registry();
+        $loader->load($registry);
+
+        $tool = $registry->getTool('devmc_fixture_hello');
+        self::assertSame('devmc_fixture_hello', $tool->tool->name);
+        self::assertSame([Hello::class, 'hello'], $tool->handler);
+
+        $prompt = $registry->getPrompt('fixture_hello_prompt');
+        self::assertSame('fixture_hello_prompt', $prompt->prompt->name);
+        self::assertSame([Hello::class, 'helloPrompt'], $prompt->handler);
+
+        $resource = $registry->getResource('fixture://hello/static');
+        self::assertSame('fixture://hello/static', $resource->resource->uri);
+        self::assertSame([Hello::class, 'helloResource'], $resource->handler);
+
+        $template = $registry->getResourceTemplate('fixture://hello/{user}');
+        self::assertSame('fixture://hello/{user}', $template->resourceTemplate->uriTemplate);
+        self::assertSame([Hello::class, 'helloTemplate'], $template->handler);
+    }
+
+    public function testLoadWithoutPathDoesNotCrash(): void
+    {
+        $loader = $this->createLoader();
+        $registry = new Registry();
+        $loader->load($registry);
+
+        self::assertFalse($registry->hasTools());
+        self::assertFalse($registry->hasPrompts());
+        self::assertFalse($registry->hasResources());
+        self::assertFalse($registry->hasResourceTemplates());
+    }
+
+    public function testLoadKeepsManuallyRegisteredTool(): void
+    {
+        $loader = $this->createLoader(['Fixtures/DevMcp']);
+        $registry = new Registry();
+
+        $manuallyRegistered = $registry->registerTool(
+            new Tool('devmc_fixture_hello', 'manual', ['type' => 'object', 'properties' => [], 'required' => []], '手动注册', null),
+            static fn (): string => 'manual'
+        );
+
+        $loader->load($registry);
+
+        self::assertTrue($registry->hasTool('devmc_fixture_hello'));
+        self::assertSame($manuallyRegistered, $registry->getTool('devmc_fixture_hello'));
+        self::assertSame('manual', $registry->getTool('devmc_fixture_hello')->tool->title);
+    }
+}


### PR DESCRIPTION
## 变更内容

为 `src/DevMcp/` 内置开发工具新增单元测试，并把 GitHub Actions 的 unit job 适配到真实 MySQL/Redis 服务。关联 #15（工作流优化）。

### 新增测试（`tests/phpunit/devmcp/`）
- **SystemTest** — 覆盖 `systemInfo`、`listDependence`、`extensions`、`getPhpIni`、`getConfig`、`getEnv`、`evalCode`、`listRoutes`、`listEvents`
- **DatabaseTest** — 覆盖 `databaseConnections`（纯配置逻辑，始终执行）；`databaseExecuteSql` 实测需真实 MySQL，通过 `RequiresPhpExtension('pdo_mysql')` + `setUp()` 连接探测跳过
- **RedisTest** — 覆盖 `databaseConnections`（始终执行）；`executeRaw`/`executeLua`/`executeLuaSha` 需真实 Redis，通过 `RequiresPhpExtension('redis')` + `setUp()` 连接探测跳过

### 核心加载器测试（`tests/phpunit/server/`）
- **DevelopmentMcpLoaderTest** — 覆盖组件注册、handler 指向、空路径不崩溃、手动注册工具不被覆盖
- **DevelopmentMcpLoader 优化**：委托 SDK `DiscoveryLoader`（不清空已注册项）；按 webman finder 可用性选择 `WebmanDiscoverer` 或 SDK `Discoverer`；支持注入 `basePath`

### 测试配置与清理
- 新增 `tests/config/database.php`、`tests/config/redis.php`，由环境变量 `MCP_TEST_DB_*` / `MCP_TEST_REDIS_*` 驱动，本地默认 `127.0.0.1`
- `tests/Bootstrap.php` 追加 `database`、`redis` 配置加载，并注册 shutdown 清理 `Webman\Finder` 生成的仓库根 `runtime/` 缓存目录

### CI（`.github/workflows/pipeline.yml`）
- unit job 增加 `mysql:8.0` 与 `redis:7-alpine` 服务，含健康检查
- `setup-php` 增加 `pdo_mysql, redis` 扩展
- 注入 MySQL/Redis 连接环境变量

### 本地验证
- 本地无 MySQL/Redis 时相关用例自动跳过，其余全部通过
- `composer phpstan`（level 6，无错误）、`composer cs:check` 均通过