### PR TITLE
ci: add test coverage report with codecov

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -123,7 +123,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -111,13 +111,21 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: pdo_mysql, redis
+          coverage: pcov
 
       - name: Install Composer
         uses: ramsey/composer-install@v4
         with:
           dependency-versions: ${{ matrix.dependencies }}
       - name: Tests
-        run: vendor/bin/phpunit --testsuite=unit
+        run: vendor/bin/phpunit --testsuite=unit --coverage-clover=coverage.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   qa:
     runs-on: ubuntu-latest


### PR DESCRIPTION
本PR在GitHub Actions中配置了PCOV和Codecov，用于收集并提交单元测试的覆盖率报告，同时在README.md中添加了Codecov Badge。