### PR TITLE
ci: split testsuites and separate coverage workflow to run on push

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,67 @@
+name: coverage
+
+on:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: webman_mcp_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      MCP_TEST_DB_HOST: 127.0.0.1
+      MCP_TEST_DB_PORT: 3306
+      MCP_TEST_DB_DATABASE: webman_mcp_test
+      MCP_TEST_DB_USERNAME: root
+      MCP_TEST_DB_PASSWORD: root
+      MCP_TEST_REDIS_HOST: 127.0.0.1
+      MCP_TEST_REDIS_PORT: 6379
+      MCP_TEST_REDIS_DATABASE: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: pdo_mysql, redis
+          coverage: pcov
+
+      - name: Install Composer
+        uses: ramsey/composer-install@v4
+        with:
+          dependency-versions: highest
+
+      - name: Tests
+        run: vendor/bin/phpunit --testsuite=unit,console --coverage-clover=coverage.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,7 +19,7 @@ jobs:
             extension: 'swoole'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -104,7 +104,7 @@ jobs:
       MCP_TEST_REDIS_DATABASE: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -118,19 +118,13 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
       - name: Tests
-        run: vendor/bin/phpunit --testsuite=unit --coverage-clover=coverage.xml
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+        run: vendor/bin/phpunit --testsuite=unit,console
 
   qa:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,11 @@
          bootstrap="tests/Bootstrap.php">
     <testsuites>
         <testsuite name="unit">
-            <directory>tests/phpunit</directory>
+            <directory>tests/phpunit/server</directory>
+            <directory>tests/phpunit/devmcp</directory>
+        </testsuite>
+        <testsuite name="console">
+            <directory>tests/phpunit/console</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
本 PR 拆分了测试套件为 unit 和 console，并且将 Codecov 覆盖率上报逻辑提取到了新文件 coverage.yml 中，只在合并/提交到 master 分支时运行；原来的 pipeline.yml 仅在 PR 时运行测试，并不再重复上传 Codecov，以节省 Action 额度。