### PR TITLE
test: exclude config, Exception, and Install.php from coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,37 +10,6 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: webman_mcp_test
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd="redis-cli ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
-    env:
-      MCP_TEST_DB_HOST: 127.0.0.1
-      MCP_TEST_DB_PORT: 3306
-      MCP_TEST_DB_DATABASE: webman_mcp_test
-      MCP_TEST_DB_USERNAME: root
-      MCP_TEST_DB_PASSWORD: root
-      MCP_TEST_REDIS_HOST: 127.0.0.1
-      MCP_TEST_REDIS_PORT: 6379
-      MCP_TEST_REDIS_DATABASE: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -52,13 +21,20 @@ jobs:
           extensions: pdo_mysql, redis
           coverage: pcov
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.composer/cache
+          key: php-8.1-composer-locked-${{ hashFiles('composer.lock') }}
+          restore-keys: php-8.1-composer-locked-
+
       - name: Install Composer
         uses: ramsey/composer-install@v4
         with:
           dependency-versions: highest
 
       - name: Tests
-        run: vendor/bin/phpunit --testsuite=unit,console --coverage-clover=coverage.xml
+        run: vendor/bin/phpunit --testsuite=unit --coverage-clover=coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,6 +39,13 @@ jobs:
         if: ${{ matrix.extension == 'swow' && (runner.os == 'Windows' || runner.os == 'macOS') }}
         run: sudo pie install swow/swow-extension --skip-enable-extension
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.composer/cache
+          key: php-${{ matrix.php }}-composer-locked-${{ hashFiles('composer.lock') }}
+          restore-keys: php-${{ matrix.php }}-composer-locked-
+
       - name: Install Composer
         uses: ramsey/composer-install@v4
 
@@ -118,7 +125,13 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
       - name: Tests
-        run: vendor/bin/phpunit --testsuite=unit,console
+        run: vendor/bin/phpunit --testsuite=unit,console --coverage-clover=coverage.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   qa:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # webman-mcp
 
-![Packagist Version](https://img.shields.io/packagist/v/luoyue/webman-mcp) ![Packagist License](https://img.shields.io/packagist/l/luoyue/webman-mcp) ![PHP Version](https://img.shields.io/packagist/dependency-v/luoyue/webman-mcp/php) ![SDK Version](https://img.shields.io/packagist/dependency-v/luoyue/webman-mcp/mcp%2Fsdk?label=sdk) [![MCP](https://img.shields.io/badge/MCP-Model%20Context%20Protocol-purple)](https://modelcontextprotocol.io/) ![Packagist Downloads](https://img.shields.io/packagist/dt/luoyue/webman-mcp) ![Packagist Stars](https://img.shields.io/packagist/stars/luoyue/webman-mcp)
+![Packagist Version](https://img.shields.io/packagist/v/luoyue/webman-mcp) ![Packagist License](https://img.shields.io/packagist/l/luoyue/webman-mcp) ![PHP Version](https://img.shields.io/packagist/dependency-v/luoyue/webman-mcp/php) ![SDK Version](https://img.shields.io/packagist/dependency-v/luoyue/webman-mcp/mcp%2Fsdk?label=sdk) [![MCP](https://img.shields.io/badge/MCP-Model%20Context%20Protocol-purple)](https://modelcontextprotocol.io/) [![codecov](https://img.shields.io/codecov/c/github/lvluoyue/webman-mcp)](https://codecov.io/gh/lvluoyue/webman-mcp) ![Packagist Downloads](https://img.shields.io/packagist/dt/luoyue/webman-mcp) ![Packagist Stars](https://img.shields.io/packagist/stars/luoyue/webman-mcp)
 
 这是一个Webman框架与官方MCP PHP SDK深度集成的插件，并在SDK基础上进行了扩展，可快速创建MCP服务器。
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,5 +17,10 @@
         <include>
             <directory suffix=".php">src</directory>
         </include>
+        <exclude>
+            <directory>src/config</directory>
+            <directory>src/Exception</directory>
+            <file>src/Install.php</file>
+        </exclude>
     </source>
 </phpunit>


### PR DESCRIPTION
在 phpunit.xml.dist 的代码覆盖率（Coverage）源文件包含规则中，排除了不参与核心业务测试的 src/config 目录、src/Exception 目录以及 src/Install.php 文件，从而使代码覆盖率指标更为纯粹和准确。