### PR TITLE
fix: codecov & services configuration in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,37 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: webman_mcp_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      MCP_TEST_DB_HOST: 127.0.0.1
+      MCP_TEST_DB_PORT: 3306
+      MCP_TEST_DB_DATABASE: webman_mcp_test
+      MCP_TEST_DB_USERNAME: root
+      MCP_TEST_DB_PASSWORD: root
+      MCP_TEST_REDIS_HOST: 127.0.0.1
+      MCP_TEST_REDIS_PORT: 6379
+      MCP_TEST_REDIS_DATABASE: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
       - name: Tests
-        run: vendor/bin/phpunit --testsuite=unit,console --coverage-clover=coverage.xml
+        run: vendor/bin/phpunit --testsuite=unit --coverage-clover=coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,6 @@
         <testsuite name="unit">
             <directory>tests/phpunit/server</directory>
             <directory>tests/phpunit/devmcp</directory>
-        </testsuite>
-        <testsuite name="console">
             <directory>tests/phpunit/console</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
在 coverage 工作流中补充了 MySQL 和 Redis 服务配置，确保 Codecov 覆盖率测试能够正常跑通数据库/缓存相关测试喵。同时移除了 console 测试套件并将相关测试目录合并至 unit 套件喵。