### PR TITLE
feat: upgrade mcp/sdk to dev-main and support modern stream interception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "description": "Webman plugin luoyue/webman-mcp",
   "require": {
     "php": ">=8.1",
-    "mcp/sdk": "^0.7",
+    "mcp/sdk": "dev-main",
     "nyholm/psr7": "^1.8",
     "webman/console": "^2.1.12"
   },
@@ -42,7 +42,8 @@
     "cs:fix": "php-cs-fixer fix --verbose",
     "cs:check": "php-cs-fixer fix --dry-run --diff",
     "phpstan": "phpstan analyse --memory-limit=2G",
-    "phpstan-fix": "phpstan analyse --memory-limit=2G --fix"
+    "phpstan-fix": "phpstan analyse --memory-limit=2G --fix",
+    "conformance": "npx -y @modelcontextprotocol/conformance server --url http://127.0.0.1:8000/mcp --suite all"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/src/Server/StreamableHttpTransport.php
+++ b/src/Server/StreamableHttpTransport.php
@@ -35,11 +35,12 @@ class StreamableHttpTransport extends BaseStreamableHttpTransport
         ?StreamFactoryInterface $streamFactory = null,
         ?LoggerInterface $logger = null,
         ?iterable $middleware = null,
+        int $maxBodyBytes = self::DEFAULT_MAX_BODY_BYTES,
     ) {
         $this->connection = $request->getAttribute(TcpConnection::class);
         $this->responseFactory = $responseFactory ?? Psr17FactoryDiscovery::findResponseFactory();
         $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
-        parent::__construct($request, $responseFactory, $streamFactory, $logger, $middleware);
+        parent::__construct($request, $responseFactory, $streamFactory, $logger, $middleware, $maxBodyBytes);
     }
 
     protected function createStreamedResponse(): ResponseInterface


### PR DESCRIPTION
本PR将 mcp/sdk 升级到开发版 (dev-main) 为 0.8 版本做准备，并适配了 modern 时代 (2026-07-28 协议) 下的 stream 拦截处理，使其能在 workerman 中进行非阻塞推送喵。